### PR TITLE
flags for juvies

### DIFF
--- a/client.py
+++ b/client.py
@@ -260,7 +260,7 @@ cmd_map = {
 	ewcfg.cmd_changelocks: ewapt.manual_changelocks,
 	ewcfg.cmd_setalarm: ewapt.set_alarm,
 	ewcfg.cmd_jam: ewapt.jam,
-	#ewcfg.cmd_checkflag: ewcmd.check_flag,
+	ewcfg.cmd_checkflag: ewcmd.check_flag,
 
 
 	# revive yourself as a juvenile after having been killed.

--- a/client.py
+++ b/client.py
@@ -1110,6 +1110,22 @@ async def on_ready():
 			except:
 				ewutils.logMsg('Twitch handler hit an exception (continuing): {}'.format(json_string))
 				traceback.print_exc(file = sys.stdout)
+
+		# Clear PvP roles from juveniles who are no longer flagged.
+		if (time_now - time_last_pvp) >= ewcfg.update_pvp:
+			time_last_pvp = time_now
+
+			try:
+				for server in client.guilds:
+					juviepvp = ewrolemgr.EwRole(id_server = server.id, name = ewcfg.role_juvenile_pvp)
+					role = server.get_role(juviepvp.id_role)
+
+					# Monitor all user roles and update if a user is no longer flagged for PvP.
+					for member in role.members:
+						await ewrolemgr.updateRoles(client = client, member = member)
+
+			except:
+				ewutils.logMsg('An error occurred in the scheduled role update task')
 		
 		# Adjust the exchange rate of slime for the market.
 		try:

--- a/ewapt.py
+++ b/ewapt.py
@@ -1430,7 +1430,9 @@ async def knock(cmd = None):
 							accepted = False
 
 							user_data = EwUser(member=cmd.message.author)
-							
+							# flag juvies
+							if user_data.life_state == ewcfg.life_state_juvenile:
+								user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_knock, False)
 							user_data.persist()
 							await ewrolemgr.updateRoles(client=cmd.client, member=cmd.message.author)
 							await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, "They don't want your company, and have tipped off the authorities."))

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -1811,20 +1811,21 @@ cd_gvs_searchforbrainz = 300
 time_to_manifest = 24 * 60 * 60 # a day
 
 # PvP timer pushouts
-time_pvp_kill = 30 * 60
-time_pvp_attack = 10 * 60
+time_pvp_kill = 30 * 60 # NOT USED
+time_pvp_attack = 10 * 60 # NOT USED
 time_pvp_annex = 10 * 60 # NOT USED
-time_pvp_mine = 1 * 60 # NOT USED
-time_pvp_withdraw = 30 * 60
-time_pvp_scavenge = 3 * 60
-time_pvp_fish = 5 * 60 # NOT USED
-time_pvp_farm = 10 * 60 # NOT USED
+time_pvp_mine = 5 * 60 
+time_pvp_withdraw = 30 * 60 # NOT USED
+time_pvp_scavenge = 10 * 60 
+time_pvp_fish = 10 * 60	
+time_pvp_farm = 30 * 60 
+time_pvp_chemo = 10 * 60 
 time_pvp_spar = 5 * 60 # NOT USED
-time_pvp_enlist = 5 * 60 
+time_pvp_enlist = 5 * 60 # NOT USED
 time_pvp_knock = 1 * 60 #temp fix. will probably add spam prevention or something funny like restraining orders later
-time_pvp_duel = 3 * 60
+time_pvp_duel = 3 * 60 # NOT USED
 time_pvp_pride = 1 * 60 # NOT USED
-time_pvp_vulnerable_districts = 1 * 60
+time_pvp_vulnerable_districts = 1 * 60 # NOT USED
 
 # time to get kicked out of subzone. 
 time_kickout = 60 * 60  # 1 hour

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -3958,10 +3958,10 @@ async def check_flag(cmd):
 	user_data = EwUser(member=cmd.message.author)
 	poi = ewcfg.id_to_poi.get(user_data.poi)
 
-	if user_data.time_expirpvp < int(time.time()):
+	if user_data.life_state != ewcfg.life_state_juvenile:
+		response = "https://img.booru.org/rfck//images/2/5c00b9d105d2435546ff6d3d9f545b05650d6631.png"
+	elif user_data.time_expirpvp < int(time.time()):
 		response = "You don't have a flag."
-	elif poi.is_street and abs(user_data.time_expirpvp - int(time.time())) < 60:
-		response = "You're in a street, so the flag's always on."
 	else:
 		response = "You have {:,} seconds left on your flag.".format(abs(user_data.time_expirpvp - int(time.time())))
 

--- a/ewfarm.py
+++ b/ewfarm.py
@@ -325,11 +325,16 @@ async def reap(cmd):
 						response += "\n\n" + levelup_response
 
 					user_data.hunger += ewcfg.hunger_perfarm
+					# flag juvies
+					if user_data.life_state == ewcfg.life_state_juvenile:
+						user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_farm, False)
 					user_data.persist()
 
 					farm.time_lastsow = 0  # 0 means no seeds are currently planted
 					farm.persist()
-					#await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
+					# gangsters don't need their roles updated
+					if user_data.life_state == ewcfg.life_state_juvenile:
+						await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 
 
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))

--- a/ewfish.py
+++ b/ewfish.py
@@ -625,6 +625,9 @@ async def reel(cmd):
 		response = "You cast your fishing rod unto a sidewalk. That is to say, you've accomplished nothing. Go to a pier if you want to fish."
 
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+	# gangsters don't need their roles updated
+	if user_data.life_state == ewcfg.life_state_juvenile:
+		await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 
 async def award_fish(fisher, cmd, user_data): 
 	response = ""
@@ -819,8 +822,11 @@ async def award_fish(fisher, cmd, user_data):
 				response += levelup_response
 
 		fisher.stop()
-		# Flag the user for PvP
-		enlisted = True if user_data.life_state == ewcfg.life_state_enlisted else False
+
+		# Flag the user for PvP (juveniles only)
+		if user_data.life_state == ewcfg.life_state_juvenile:
+			user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_fish, False)
+
 		user_data.persist()
 	return response
 

--- a/ewhunting.py
+++ b/ewhunting.py
@@ -2712,7 +2712,7 @@ def get_target_by_ai(enemy_data, cannibalize = False):
 	
 		elif enemy_data.ai == ewcfg.enemy_ai_attacker_a:
 			users = ewutils.execute_sql_query(
-				"SELECT {id_user}, {life_state}, {time_lastenter} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin} OR {id_user} IN (SELECT {id_user} FROM status_effects WHERE id_status = '{repel_status}')) ORDER BY {time_lastenter} ASC".format(
+				"SELECT {id_user}, {life_state}, {time_lastenter} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND ({time_expirpvp} > {time_now} OR {life_state} != {life_state_juvenile}) AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin} OR {id_user} IN (SELECT {id_user} FROM status_effects WHERE id_status = '{repel_status}')) ORDER BY {time_lastenter} ASC".format(
 					id_user = ewcfg.col_id_user,
 					life_state = ewcfg.col_life_state,
 					time_lastenter = ewcfg.col_time_lastenter,
@@ -2721,8 +2721,10 @@ def get_target_by_ai(enemy_data, cannibalize = False):
 					targettimer = targettimer,
 					life_state_corpse = ewcfg.life_state_corpse,
 					life_state_kingpin = ewcfg.life_state_kingpin,
-					life_state_shambler = ewcfg.life_state_shambler,
+					life_state_juvenile = ewcfg.life_state_juvenile,
 					repel_status = ewcfg.status_repelled_id,
+					time_expirpvp = ewcfg.col_time_expirpvp,
+					time_now = time_now,
 				), (
 					enemy_data.poi,
 					enemy_data.id_server
@@ -2732,7 +2734,7 @@ def get_target_by_ai(enemy_data, cannibalize = False):
 	
 		elif enemy_data.ai == ewcfg.enemy_ai_attacker_b:
 			users = ewutils.execute_sql_query(
-				"SELECT {id_user}, {life_state}, {slimes} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin} OR {id_user} IN (SELECT {id_user} FROM status_effects WHERE id_status = '{repel_status}')) ORDER BY {slimes} DESC".format(
+				"SELECT {id_user}, {life_state}, {slimes} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND ({time_expirpvp} > {time_now} OR {life_state} != {life_state_juvenile}) AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin} OR {id_user} IN (SELECT {id_user} FROM status_effects WHERE id_status = '{repel_status}')) ORDER BY {slimes} DESC".format(
 					id_user = ewcfg.col_id_user,
 					life_state = ewcfg.col_life_state,
 					slimes = ewcfg.col_slimes,
@@ -2742,8 +2744,10 @@ def get_target_by_ai(enemy_data, cannibalize = False):
 					targettimer = targettimer,
 					life_state_corpse = ewcfg.life_state_corpse,
 					life_state_kingpin = ewcfg.life_state_kingpin,
-					life_state_shambler = ewcfg.life_state_shambler,
+					life_state_juvenile = ewcfg.life_state_juvenile,
 					repel_status = ewcfg.status_repelled_id,
+					time_expirpvp = ewcfg.col_time_expirpvp,
+					time_now = time_now,
 				), (
 					enemy_data.poi,
 					enemy_data.id_server

--- a/ewjuviecmd.py
+++ b/ewjuviecmd.py
@@ -502,11 +502,18 @@ async def mine(cmd):
 			if was_levelup:
 				response += levelup_response
 
+			# flag juvies
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_mine, False)
+
 			user_data.persist()
 
 			if printgrid:
 				await print_grid(cmd)
 
+			# gangsters don't need their roles updated
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 
 	else:
 		return await mismine(cmd, user_data, "channel")
@@ -850,10 +857,18 @@ async def scavenge(cmd):
 
 			user_data.time_lastscavenge = time_now
 
+			# flag juvies
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_scavenge, False)
+
 			user_data.persist()
 
 			if not response == "":
 				await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+			# gangsters don't need their roles updated
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 	else:
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, "You'll find no slime here, this place has been picked clean. Head into the city to try and scavenge some slime."))
 

--- a/ewmutation.py
+++ b/ewmutation.py
@@ -9,6 +9,7 @@ import ewcfg
 import ewstats
 import ewutils
 import ewitem
+import ewrolemgr
 from ewmarket import EwMarket
 from ewplayer import EwPlayer
 
@@ -355,6 +356,9 @@ async def chemo(cmd):
 		else:
 			price = ewcfg.mutations_map.get(target).tier * 5000
 			user_data.change_slimes(n=-price, source=ewcfg.source_spending)
+			# flag juvies
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_chemo, False)	
 			user_data.persist()
 
 			try:
@@ -370,7 +374,10 @@ async def chemo(cmd):
 			except:
 				ewutils.logMsg("Failed to clear mutations for user {}.".format(user_data.id_user))
 			response = '"Alright, dearie, let\'s get you purged." You enter a dingy looking operating room, with slime strewn all over the floor. Dr. Dusttrap pulls out a needle the size of your bicep and injects into odd places on your body. After a few minutes of this, you get fatigued and go under.\n\n You wake up and {} is gone. Nice! \nMutation Levels Added:{}/{}'.format(ewcfg.mutations_map.get(target).str_name, user_data.get_mutation_level(), min(user_data.slimelevel, 50))
-			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+			await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+			
+			if user_data.life_state == ewcfg.life_state_juvenile:
+				await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 
 async def graft(cmd):
 	user_data = EwUser(member=cmd.message.author)
@@ -416,11 +423,16 @@ async def graft(cmd):
 	else:
 		price = ewcfg.mutations_map.get(target).tier * 10000
 		user_data.change_slimes(n=-price, source=ewcfg.source_spending)
+		# flag juvies
+		if user_data.life_state == ewcfg.life_state_juvenile:
+			user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_chemo, False)		
 		user_data.persist()
 		user_data.add_mutation(id_mutation=target, is_artificial=1)
 		response = ewcfg.mutations_map[target].str_transplant + "\n\nMutation Levels Added:{}/{}".format(user_data.get_mutation_level(), min(user_data.slimelevel, 50))
-		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
-
+		await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+		
+		if user_data.life_state == ewcfg.life_state_juvenile:
+			await ewrolemgr.updateRoles(client = cmd.client, member = cmd.message.author)
 
 async def clear_mutations(cmd):
 	user_data = EwUser(member = cmd.message.author)

--- a/ewrolemgr.py
+++ b/ewrolemgr.py
@@ -411,11 +411,26 @@ async def updateRoles(
 
 	faction_roles_remove.remove(faction_role)
 
+	non_wanted_pois = [
+		ewcfg.poi_id_copkilltown, 
+		ewcfg.poi_id_rowdyroughhouse, 
+		ewcfg.poi_id_juviesrow, 
+		ewcfg.poi_id_thebreakroom,
+		ewcfg.poi_id_mine, 
+		ewcfg.poi_id_mine_bubble, 
+		ewcfg.poi_id_mine_sweeper, 
+		ewcfg.poi_id_juviesrow_pier, 
+		ewcfg.poi_id_jr_farms
+	 ]
+
 	pvp_role = None
 	active_role = None
 	if faction_role in ewcfg.role_to_pvp_role:
 
-		if not user_poi.is_apartment and user_poi.id_poi not in [ewcfg.poi_id_copkilltown, ewcfg.poi_id_rowdyroughhouse, ewcfg.poi_id_juviesrow, ewcfg.poi_id_thebreakroom]:
+		if not user_poi.is_apartment and \
+		user_poi.id_poi not in non_wanted_pois and \
+		user_data.life_state != ewcfg.life_state_juvenile or \
+		(user_data.life_state == ewcfg.life_state_juvenile and user_data.time_expirpvp >= time_now):
 			pvp_role = ewcfg.role_to_pvp_role.get(faction_role)
 			faction_roles_remove.remove(pvp_role)
 

--- a/ewwep.py
+++ b/ewwep.py
@@ -429,7 +429,7 @@ def canAttack(cmd, amb_switch = 0):
 			# Target is possessing user's weapon
 			response = "{}'s contract forbids you from harming them. You should've read the fine print.".format(member.display_name)
 
-		elif not poi.pvp and not (shootee_data.life_state == ewcfg.life_state_shambler or shootee_data.get_inhabitee() == user_data.id_user or user_isshambler):
+		elif not poi.pvp and not (shootee_data.life_state == ewcfg.life_state_shambler or shootee_data.get_inhabitee() == user_data.id_user or user_isshambler) or (shootee_data.life_state == ewcfg.life_state_juvenile and time_now > shootee_data.time_expirpvp):
 			# Target is neither flagged for PvP, nor a shambler, nor a ghost inhabiting the player. Player is not a shambler.
 			response = "{} is not mired in the ENDLESS WAR right now.".format(member.display_name)
 

--- a/json/poi.json
+++ b/json/poi.json
@@ -1290,7 +1290,8 @@
             "cratersville": 60,
             "rowdyroughhouse": 60,
             "smokerscough": 20,
-            "wreckingtonsubwaystation": 20
+            "wreckingtonsubwaystation": 20,
+            "wreckingtonport": 20
         },
         "topic": "A former residential district that's now mostly demolished. Go here if you want to wreck some shit, no one will care.",
         "wikipage": "https://rfck.miraheze.org/wiki/Wreckington"
@@ -1488,7 +1489,8 @@
             "newnewyonkers": 60,
             "oldnewyonkers": 60,
             "thekingswifessonspeakeasy": 20,
-            "vagrantscornersubwaystation": 20
+            "vagrantscornersubwaystation": 20,
+            "vagrantscornerport": 20
         },
         "topic": "Dingy port district and site of innumerable shady back-alley dealings.",
         "wikipage": "https://rfck.miraheze.org/wiki/Vagrant's_Corner"


### PR DESCRIPTION
- Juveniles can't be killed for just being in districts, they need to be flagged.
List of actions that cause you to be flagged and their timers:
Mining -> 5 minutes
Scavenging -> 10 minutes
Knocking -> 1 minutes
Reaping -> 30 minutes
Reeling fish -> 10 minutes
Grafting or chemo -> 10 minutes

- Because of this, !checkflag can be used again.

Unrelated to juvies - Being in Juvies Row subzones no longer gives you the Wanted role.
Note: juvies get the wanted role even in gang bases and JR. This is just so they can know they're flagged.