### PR TITLE
QoL: Check mastery command

### DIFF
--- a/client.py
+++ b/client.py
@@ -841,7 +841,10 @@ cmd_map = {
 	# Slime Twitter
 	ewcfg.cmd_tweet: ewslimetwitter.tweet,
 	ewcfg.cmd_verification: ewslimetwitter.verification,
-	ewcfg.cmd_verification_alt: ewslimetwitter.verification
+	ewcfg.cmd_verification_alt: ewslimetwitter.verification,
+
+	# Check your weapon masteries
+	ewcfg.cmd_mastery: ewcmd.check_mastery
 }
 
 debug = False

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -1322,6 +1322,7 @@ cmd_untakedown = cmd_prefix + 'untakedown'
 cmd_untakedown_alt_1 = cmd_prefix + 'uncopyrightstrike'
 cmd_untakedown_alt_2 = cmd_prefix + 'undeletezine'
 cmd_lol = cmd_prefix + 'lol'
+cmd_mastery = cmd_prefix + 'mastery'
 
 apartment_b_multiplier = 1500
 apartment_a_multiplier = 2000000

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -3975,3 +3975,16 @@ async def check_flag(cmd):
 
 	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 	"""
+async def check_mastery(cmd):
+	message_line = "You are a rank {} master of the {}. \n"
+	message = "\nYou close your eyes for a moment, recalling your masteries. \n"
+	if cmd.mentions_count > 0:
+		response = "You can only recall your own weapon masteries!"
+	else:
+		wepskills = ewutils.weaponskills_get(member=cmd.message.author)
+		for skill, level in wepskills.items():
+			message += message_line.format(level["skill"], skill.lower())
+		response = message
+
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+


### PR DESCRIPTION
Now players can do !mastery to check all of their masteries (weapons and tools) in one easy command. Instead of having to !data yourself while switching between different weapons and tools to check your skill levels, you can just check all of them with one simple command.

I left out the ability for players to !mastery check others on purpose to avoid any possible easy surveillance of other people's masteries.