### PR TITLE
Adding cache

### DIFF
--- a/client.py
+++ b/client.py
@@ -1203,6 +1203,15 @@ if token == None or len(token) == 0:
     ewutils.logMsg('Please place your API token in a file called "token", in the same directory as this script.')
     sys.exit(0)
 
+# Load the cache before connecting to discord, this way we arent missing heartbeats
+ewutils.logMsg("Initializing caches...")
+
+# Set all predefined caches to enabled and initialize them
+for cache_type_name in ewcfg.cacheable_types:
+    ewutils.logMsg("Initializing {} cache.".format(cache_type_name))
+    bknd_core.enabled_caches.append(cache_type_name)
+    bknd_core.ObjCache(ew_obj_type=cache_type_name)
+
 # connect to discord and run indefinitely
 try:
     client.run(token)

--- a/client.py
+++ b/client.py
@@ -120,6 +120,21 @@ if debug == True:
 
 ewutils.logMsg('Using database: {}'.format(ewcfg.database))
 
+ewcfg.debugroom = ewdebug.debugroom
+ewcfg.debugroom_short = ewdebug.debugroom_short
+ewcfg.debugpiers = ewdebug.debugpiers
+ewcfg.debugfish_response = ewdebug.debugfish_response
+ewcfg.debugfish_goal = ewdebug.debugfish_goal
+ewcfg.cmd_debug1 = ewcfg.cmd_prefix + ewdebug.cmd_debug1
+ewcfg.cmd_debug2 = ewcfg.cmd_prefix + ewdebug.cmd_debug2
+ewcfg.cmd_debug3 = ewcfg.cmd_prefix + ewdebug.cmd_debug3
+ewcfg.cmd_debug4 = ewcfg.cmd_prefix + ewdebug.cmd_debug4
+# ewcfg.debug5 = ewdebug.debug5
+ewcfg.cmd_debug6 = ewcfg.cmd_prefix + ewdebug.cmd_debug6
+ewcfg.cmd_debug7 = ewcfg.cmd_prefix + ewdebug.cmd_debug7
+ewcfg.cmd_debug8 = ewcfg.cmd_prefix + ewdebug.cmd_debug8
+ewcfg.cmd_debug9 = ewcfg.cmd_prefix + ewdebug.cmd_debug9
+
 
 @client.event
 async def on_member_remove(member):

--- a/ew/backend/core.py
+++ b/ew/backend/core.py
@@ -1,4 +1,5 @@
 import time
+from copy import copy
 
 import MySQLdb
 
@@ -7,8 +8,201 @@ from ..static import cfg as ewcfg
 db_pool = {}
 db_pool_id = 0
 
-""" connect to the database """
+caches = []
+enabled_caches = []
 
+cache_type_to_load_fn = {}
+
+
+class ObjCache():
+    """
+        Template for caches. Initialized with the type.__name__ of the objects it stores.
+        Handles setting and retrieval of cached data, ensuring that all data entering or exiting the cache is
+        identified and copied as its type should be, and that the data within the cache is never directly pointed to
+        by an external function.
+        This ensures that the cache is only updated when these methods are called, and in the case where an object is
+        initialized and changed without being persisted, that the cached data is not affected
+    """
+
+    entry_type = None
+
+    identifiers = []
+    nested_props = []
+    entries = {}
+
+    def __init__(self, ew_obj_type=None):
+        """
+            Takes the string representing the class type. Found with `type(instance).__name__`
+            Sets up type specific variables used in the cache.
+        """
+
+        # Track the object type stored in the cache
+        self.entry_type = ew_obj_type
+
+        # If this isn't done all instances use the same dict
+        self.entries = {}
+
+        # Check if it has been given an identifying column
+        if ew_obj_type in ewcfg.obj_type_to_identifiers.keys():
+            # declare the unique columns
+            self.identifiers = ewcfg.obj_type_to_identifiers.get(ew_obj_type)
+
+        # Find any nested properties so copying will work right
+        if ew_obj_type in ewcfg.obj_type_to_nested_props.keys():
+            self.nested_props = ewcfg.obj_type_to_nested_props.get(ew_obj_type)
+
+        # Leave a pointer to this object so it can actually be found
+        caches.append(self)
+
+        # Load the cache if there are instructions for doing so
+        if (ew_obj_type in cache_type_to_load_fn.keys()) and (ew_obj_type in ewcfg.autoload_types):
+            cache_type_to_load_fn.get(ew_obj_type)()
+
+    def get_data_id(self, data):
+        """
+            Takes a dictionary of property names and values. Must at least contain the unique properties of the type.
+            Returns a string combining all unique properties, or False if a unique property is not present in the data.
+
+            Unnecessary for EwItems or EwPlayers, which have only one unique property. But necessary for expansion into
+            EwUsers or stocks which combine multiple fields to achieve unique identification
+        """
+
+        # Set Up
+        return_id = None
+
+        # Iterate through all identifying properties
+        for prop_type in self.identifiers:
+            # Allow for entry_id to be recognized as user_id or item_id etc.
+            shared_names = [name for name in data.keys() if name in prop_type]
+
+            # Handle the value if it exists
+            if shared_names:
+                prop_val = data.get(shared_names[0])
+                # Format the value based on whether it's the first, and add to the final id
+                return_id = str(prop_val) if (return_id is None) else "{}~{}".format(return_id, prop_val)
+            else:
+                # Data is missing a necessary identifier
+                return False
+
+        # Return the made identifier
+        if return_id is not None:
+            return return_id
+        elif len(self.identifiers) == 0:
+            # If the type has no identifiers, then simple number the entries as they come in.
+            # Everything from the DB should have a unique column or pair of, this shouldn't ever be used
+            return str(len(self.entries) + 1)
+
+    def copy_entry(self, data):
+        """
+            Takes the data of an entry for the cache's given type.
+            Returns a surface copy of the data, with any fields defined as nested being surface copied individually.
+
+            Deepcopy works for the most part, but threw errors when used on EwPlayer data, so while those are not being
+            cached yet, the potential issue was pre-emptively fixed when found.
+        """
+
+        # Run a surface level copy
+        ret_dat = copy(data)
+
+        # Since the caches are being typed, we know what values will be too deep to copy. So Get those replaced
+        for prop in self.nested_props:
+            # Ensure the data has the prop, then copy and replace
+            if prop in ret_dat.keys():
+                # Ensure the pointing entry is removed
+                ret_dat.pop(prop)
+
+                # And replaced with the copy
+                prop_cop = copy(data.get(prop))
+                ret_dat.update({prop: prop_cop})
+
+            else:
+                # Data was incompatible, make it known
+                return False
+
+        return ret_dat
+
+    def set_entry(self, data):
+        """
+            Takes data of the cache's entry type and updates the cache with a new copy of the data.
+            Returns true if successful, and False if it was unable to find the identifier or make a copy.
+        """
+
+        # Attempt to get unique ID for the data
+        entry_id = self.get_data_id(data)
+        # Ensure saved data is separated from active use data
+        unique_data = self.copy_entry(data)
+
+        # Save it if it's real, if it's missing a property it should have, one of these should return false
+        if (entry_id is not False) and (unique_data is not False):
+            self.entries.update({entry_id: unique_data})
+            return True
+        else:
+            print("Cache for {}s was passed incompatible or incomplete data. \nData Passed: {}".format(self.entry_type, data))
+            return False
+
+    def get_entry(self, unique_vals = None):
+        """
+            Takes dictionary of the values unique to all entries. Should just be the Primary Keys.
+            Returns a copy of the cached data, or False if there is no data with the given identifiers.
+        """
+
+        # Convert identifiers to a string of consistent order and format
+        id_str = self.get_data_id(unique_vals)
+
+        # Find the target data and copy it so nothing receives a pointer to the cache
+        return self.copy_entry(self.entries.get(id_str)) if (id_str in self.entries.keys()) else False
+
+    def delete_entry(self, unique_vals = None):
+        """
+            Takes the unique properties of a given entry as a dictionary of property names and values.
+            Returns True if the entry existed and was removed, returns false if nothing was found
+            Deletes entry if one matching the passed identifiers is found
+        """
+
+        # Convert identifiers to a string of consistent order and format
+        id_str = self.get_data_id(unique_vals)
+
+        if id_str in self.entries.keys():
+            # Delete the entry if it exists
+            self.entries.pop(id_str)
+
+            # Allow for things that use this to know whether something was successfully deleted
+            return True
+        return False
+
+    def find_entries(self, criteria = None):
+        """
+            Takes a dictionary of object property names and values. Checks against all data entered in the cache.
+            Returns a list of copies of all data that met the given criteria.
+        """
+
+        copied_matches = []
+
+        # iterate through all entered data
+        for data in self.entries.values():
+
+            # Check against all given criteria
+            meets = True
+            for key, value in criteria.items():
+                # For search through props type things
+                if key in self.nested_props:
+                    for k2, v2 in value.items():
+                        if not (k2 in data.get(key).keys() and str(v2) == str(data.get(key).get(k2))):
+                            meets = False
+                            break
+                # Stop and mark if it isn't a match
+                elif not ((key in data.keys()) and (str(value) == str(data.get(key)))):
+                    meets = False
+                    break
+
+            # track data if it matches
+            if meets:
+                copied_matches.append(self.copy_entry(data))
+
+        return copied_matches
+
+
+""" connect to the database """
 
 def databaseConnect():
     conn_info = None
@@ -64,12 +258,14 @@ def databaseClose(conn_info):
 
 
 """
-	Execute a given sql_query. (the purpose of this function is to minimize repeated code and keep functions readable)
+    Execute a given sql_query. (the purpose of this function is to minimize repeated code and keep functions readable)
 """
 
 
 def execute_sql_query(sql_query = None, sql_replacements = None):
     data = None
+    cursor = None
+    conn_info = None
 
     try:
         conn_info = databaseConnect()
@@ -81,7 +277,104 @@ def execute_sql_query(sql_query = None, sql_replacements = None):
         conn.commit()
     finally:
         # Clean up the database handles.
-        cursor.close()
-        databaseClose(conn_info)
+        if cursor is not None: cursor.close()
+        if conn_info is not None: databaseClose(conn_info)
 
     return data
+
+
+""" Locate the cache, compile all given identifying values, and get the entry with the given identification and type """
+
+
+def get_cache_result(obj_type = None, obj = None, **kwargs):
+    """
+        Takes an object type and any given properties, or an object itself
+        Returns False on failure to find, otherwise returns specified entry data
+
+        Any unspecified keywords will be assumed to be unique properties, and a given object will be considered the
+        an instance of the target object, and have its properties added as potential identifiers
+    """
+
+    # Setup for return, and grab the cache if it exists
+    obj_cache = get_cache(obj_type = obj_type, obj = obj, create = False)
+
+    # This ensures a proper type was passed
+    if obj_cache is not False:
+        # Use given object's properties as example of target object
+        if obj is not None: kwargs.update(obj.__dict__)
+
+        # Look for and return entry with values matching what was given.
+        return obj_cache.get_entry(unique_vals=kwargs)
+
+    # Return False if the type is not cached
+    return False
+
+
+def cache_data(obj_type = None, data = None, obj = None):
+    """
+        Takes an object's type and data, or the object itself. Will prioritize given "data" if mixed with an object.
+        Returns True if it was successfully cached, and false if given incomplete or incompatible data.
+
+        Will create a new cache if one does not yet exist for the given object type.
+    """
+
+    # Find or create the cache
+    type_cache = get_cache(obj_type = obj_type, obj = obj, create = True)
+
+    # Extracts the data from an object if that was passed in lieu of necessitating separating the values elsewhere
+    data = obj.__dict__ if ((data is None) and (obj is not None)) else data
+
+    # Get cache will return false if not passed a proper object type
+    if type_cache is not False:
+        # Attempt to save the given data in the cache of its type
+        return type_cache.set_entry(data)
+
+    # Indicate failure to find a cache
+    return False
+
+
+def remove_entry(obj_type = None, obj = None, **kwargs):
+    """
+        Takes the type of object or the object itself being targeted
+        Returns True or False if the cached data was found and removed or not
+
+        Extra keywords are assumed to be unique properties of the target data, as are all properties of a passed obj
+    """
+
+    # Attempt to find pre-existing cache of the specified type
+    type_cache = get_cache(obj_type = obj_type, obj = obj, create = False)
+
+    # If the cache was found, try to find and delete an entry with the given properties.
+    if type_cache is not False:
+        # if the entire object was given, use its properties for identification
+        if obj is not None: kwargs.update(obj.__dict__)
+        # attempt deletion and indicate success
+        return type_cache.delete_entry(unique_vals = kwargs)
+
+    # Return indicator of success
+    return False
+
+
+def get_cache(obj_type=None, obj = None, create=False):
+    """
+        Takes the type().__name__ of an object or an object, and bool determining creation
+        Returns a cache of the specified type if create, or if it already exists, otherwise False
+    """
+
+    # Allow for passing of entire objects in the place of having to pick over the data every time
+    obj_type = type(obj).__name__ if ((obj_type is None) and (obj is not None)) else obj_type
+
+    # Ensure a valid type was actually given
+    if obj_type in enabled_caches:
+        # Search through all caches
+        for cache in caches:
+            # Return the cache upon finding it
+            if cache.entry_type == obj_type:
+                return cache
+
+        if create:
+            # If no matching cache was found, create a new one and return it, unless specified otherwise
+            return ObjCache(ew_obj_type=obj_type)
+
+    # Return false if No cache was found or creatable
+    return False

--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -190,7 +190,7 @@ class EwItem:
     def update_name(self):
         if self.name == "":
             for key, value in self.item_props.items():
-                if key in ["item_name", "food_name", "cosmetic_name", "weapon_name"]:
+                if key in ["item_name", "food_name", "cosmetic_name", "weapon_name", "furniture_name"]:
                     self.name = value
             if self.name == "" and "weapon_type" in self.item_props.keys():
                 self.name = self.item_props.get("weapon_type")

--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -29,6 +29,8 @@ class EwItem:
 
     item_props = None
 
+    name = ""
+
     def __init__(
             self,
             id_item = None
@@ -40,67 +42,77 @@ class EwItem:
             # the item props don't reset themselves automatically which is why the items_prop table had tons of extraneous rows (like food items having medal_names)
             # self.item_props.clear()
 
-            try:
-                conn_info = bknd_core.databaseConnect()
-                conn = conn_info.get('conn')
-                cursor = conn.cursor()
+            cache_result = bknd_core.get_cache_result(obj = self)
+            if cache_result is not False:
+                self.__dict__ = cache_result
+            else:
+                try:
+                    conn_info = bknd_core.databaseConnect()
+                    conn = conn_info.get('conn')
+                    cursor = conn.cursor()
 
-                # Retrieve object
-                cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM items WHERE id_item = %s".format(
-                    ewcfg.col_id_server,
-                    ewcfg.col_id_user,
-                    ewcfg.col_item_type,
-                    ewcfg.col_time_expir,
-                    ewcfg.col_stack_max,
-                    ewcfg.col_stack_size,
-                    ewcfg.col_soulbound,
-                    ewcfg.col_template
-                ), (
-                    self.id_item,
-                ))
-                result = cursor.fetchone()
-
-                if result != None:
-                    # Record found: apply the data to this object.
-                    self.id_server = result[0]
-                    self.id_owner = result[1]
-                    self.item_type = result[2]
-                    self.time_expir = result[3]
-                    self.stack_max = result[4]
-                    self.stack_size = result[5]
-                    self.soulbound = (result[6] != 0)
-                    self.template = result[7]
-
-                    # Retrieve additional properties
-                    cursor.execute("SELECT {}, {} FROM items_prop WHERE id_item = %s".format(
-                        ewcfg.col_name,
-                        ewcfg.col_value
+                    # Retrieve object
+                    cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM items WHERE id_item = %s".format(
+                        ewcfg.col_id_server,
+                        ewcfg.col_id_user,
+                        ewcfg.col_item_type,
+                        ewcfg.col_time_expir,
+                        ewcfg.col_stack_max,
+                        ewcfg.col_stack_size,
+                        ewcfg.col_soulbound,
+                        ewcfg.col_template
                     ), (
                         self.id_item,
                     ))
+                    result = cursor.fetchone()
 
-                    for row in cursor:
-                        # this try catch is only necessary as long as extraneous props exist in the table
-                        try:
-                            self.item_props[row[0]] = row[1]
-                        except:
-                            ewutils.logMsg("extraneous item_prop row detected.")
+                    if result != None:
+                        # Record found: apply the data to this object.
+                        self.id_server = result[0]
+                        self.id_owner = result[1]
+                        self.item_type = result[2]
+                        self.time_expir = result[3]
+                        self.stack_max = result[4]
+                        self.stack_size = result[5]
+                        self.soulbound = (result[6] != 0)
+                        self.template = result[7]
 
-                else:
-                    # Item not found.
-                    self.id_item = -1
+                        # Retrieve additional properties
+                        cursor.execute("SELECT {}, {} FROM items_prop WHERE id_item = %s".format(
+                            ewcfg.col_name,
+                            ewcfg.col_value
+                        ), (
+                            self.id_item,
+                        ))
 
-                if self.template == "-2":
-                    self.persist()
+                        for row in cursor:
+                            # this try catch is only necessary as long as extraneous props exist in the table
+                            try:
+                                self.item_props[row[0]] = row[1]
+                            except:
+                                ewutils.logMsg("extraneous item_prop row detected.")
 
-            finally:
-                # Clean up the database handles.
-                cursor.close()
-                bknd_core.databaseClose(conn_info)
+                    else:
+                        ewutils.logMsg("Item {} not found in cache or db".format(id_item))
+                        # Item not found.
+                        self.id_item = -1
+
+                    if self.template == "-2":
+                        self.persist()
+
+                    self.update_name()
+                    bknd_core.cache_data(obj = self)
+
+                finally:
+                    # Clean up the database handles.
+                    cursor.close()
+                    bknd_core.databaseClose(conn_info)
 
     """ Save item data object to the database. """
 
     def persist(self):
+
+        self.update_name()
 
         if self.template == "-2":
             if self.item_type == ewcfg.it_item:
@@ -119,6 +131,8 @@ class EwItem:
                 self.template = "MEDAL ITEM????"  # p sure these are fake news
             elif self.item_type == ewcfg.it_questitem:
                 self.template = "QUEST ITEM????"
+
+        bknd_core.cache_data(obj=self)
 
         try:
             conn_info = bknd_core.databaseConnect()
@@ -173,6 +187,14 @@ class EwItem:
             cursor.close()
             bknd_core.databaseClose(conn_info)
 
+    def update_name(self):
+        if self.name == "":
+            for key, value in self.item_props.items():
+                if key in ["item_name", "food_name", "cosmetic_name", "weapon_name"]:
+                    self.name = value
+            if self.name == "" and "weapon_type" in self.item_props.keys():
+                self.name = self.item_props.get("weapon_type")
+
 
 """
 	Finds the amount of Slime Poudrins inside your inventory.
@@ -201,13 +223,15 @@ def find_poudrin(id_user = None, id_server = None):
 
 
 """
-	Delete the specified item by ID. Also deletes all items_prop values.
+    Delete the specified item by ID. Also deletes all items_prop values.
 """
 
 
 def item_delete(
         id_item = None
 ):
+    bknd_core.remove_entry(obj_type="EwItem", id_entry=id_item)
+
     try:
         conn_info = bknd_core.databaseConnect()
         conn = conn_info.get('conn')
@@ -230,9 +254,9 @@ def item_delete(
 
 
 """
-	Create a new item and give it to a player.
+    Create a new item and give it to a player.
 
-	Returns the unique database ID of the newly created item.
+    Returns the unique database ID of the newly created item.
 """
 
 
@@ -317,6 +341,7 @@ def item_create(
         cursor.close()
         bknd_core.databaseClose(conn_info)
 
+    EwItem(id_item=item_id) # Ensure it is loaded into the cache
     return item_id
 
 
@@ -337,12 +362,22 @@ def item_dropall(
                 user_data.id_server
             ))
 
+        # Get the item cache if it exists
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache:
+            # Get all non soulbound items belonging to the user in their current server
+            criteria_for_drop = {"id_owner": user_data.id_user, "id_server": user_data.id_server, "soulbound": False}
+            for item_data in item_cache.find_entries(criteria=criteria_for_drop):
+                # Give the items to the floor
+                item_data.update({"id_owner": user_data.poi})
+                item_cache.set_entry(item_data)
+
     except:
         ewutils.logMsg('Failed to drop items for user with id {}'.format(user_data.id_user))
 
 
 """
-	Dedorn all of a player's cosmetics
+    Dedorn all of a player's cosmetics
 """
 
 
@@ -364,12 +399,25 @@ def item_dedorn_cosmetics(
                 id_server
             ))
 
+        # Get the item cache if it exists
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache:
+            # Find all adorned items belonging to the given user in that server
+            for item_data in item_cache.find_entries(criteria={
+                "id_owner": id_user,
+                "id_server": id_server,
+                "item_props": {"adorned": "true"}
+            }):
+                # change the tag to dedorned and save the data
+                item_data.get("item_props").update({"adorned": False})
+                item_cache.set_entry(item_data)
+
     except:
         ewutils.logMsg('Failed to dedorn cosmetics for user with id {}'.format(id_user))
 
 
 """
-	Destroy all of a player's non-soulbound items.
+    Destroy all of a player's non-soulbound items.
 """
 
 
@@ -395,6 +443,16 @@ def item_destroyall(id_server = None, id_user = None, member = None):
             ))
 
             conn.commit()
+
+            # Get the item cache if it's being used
+            item_cache = bknd_core.get_cache(obj_type = "EwItem")
+            if item_cache:
+                # Find all non soulbound items belonging to the given user in that server
+                destruction_criteria = {"id_owner": id_user, "id_server": id_server, "soulbound": False}
+                for item_data in item_cache.find_entries(criteria=destruction_criteria):
+                    # attempt to delete the item from cache
+                    item_cache.delete_entry(item_data)
+
         finally:
             # Clean up the database handles.
             cursor.close()
@@ -402,7 +460,7 @@ def item_destroyall(id_server = None, id_user = None, member = None):
 
 
 """
-	Loot all non-soulbound items from a player upon killing them, reassinging to id_user_target.
+    Transfers adorned cosmetics and equipped weapons (no sidearms) from the source to the target.
 """
 
 
@@ -413,28 +471,29 @@ def item_loot(
     if source_data == None or target_data == None:
         return
 
-    try:
-        # Transfer adorned cosmetics
-        data = bknd_core.execute_sql_query(
-            "SELECT id_item FROM items " +
-            "WHERE id_user = %s AND id_server = %s AND soulbound = 0 AND item_type = %s AND id_item IN (" +
-            "SELECT id_item FROM items_prop " +
-            "WHERE name = 'adorned' AND value = 'true' " +
-            ")"
-            , (
-                source_data.id_user,
-                source_data.id_server,
-                ewcfg.it_cosmetic
-            ))
+    # Use the cache if possible
+    item_cache = bknd_core.get_cache(obj_type = "EwItem")
+    if item_cache is not False:
+        # Find all cosmetics that can be moved and are adorned
+        criteria = {
+            "id_owner": source_data.id_user,
+            "id_server": source_data.id_server,
+            "soulbound": False,
+            "item_type": ewcfg.it_cosmetic,
+            "item_props": {"adorned": "true"}
+        }
+        movable_cosmetics = item_cache.find_entries(criteria=criteria)
 
-        for row in data:
-            item_data = EwItem(id_item=row[0])
-            item_data.item_props["adorned"] = 'false'
-            item_data.id_owner = target_data.id_user
-            item_data.persist()
+        # Iterate through all found cosmetics
+        for item_data in movable_cosmetics:
+            # Dedorn the cosmetic
+            item = EwItem(id_item=item_data.get("id_item"))
+            item.item_props.update({"adorned": 'false'})
+            item.persist()
+            # Transfer ownership, abiding by capacity limits this time
+            give_item(id_user=target_data.id_user, id_server=target_data.id_server)
 
-        ewutils.logMsg('Transferred {} cosmetic items.'.format(len(data)))
-
+        # if the source has a weapon equipped
         if source_data.weapon >= 0:
             weapons_held = inventory(
                 id_user=target_data.id_user,
@@ -442,43 +501,86 @@ def item_loot(
                 item_type_filter=ewcfg.it_weapon
             )
 
+            # give the target the weapon if they have inventory space for it
             if len(weapons_held) <= target_data.get_weapon_capacity():
                 give_item(id_user=target_data.id_user, id_server=target_data.id_server, id_item=source_data.weapon)
 
-    except:
-        ewutils.logMsg("Failed to loot items from user {}".format(source_data.id_user))
+    # Use the database if there's no cache
+    else:
+
+        try:
+            # Transfer adorned cosmetics
+            data = bknd_core.execute_sql_query(
+                "SELECT id_item FROM items " +
+                "WHERE id_user = %s AND id_server = %s AND soulbound = 0 AND item_type = %s AND id_item IN (" +
+                "SELECT id_item FROM items_prop " +
+                "WHERE name = 'adorned' AND value = 'true' " +
+                ")"
+                , (
+                    source_data.id_user,
+                    source_data.id_server,
+                    ewcfg.it_cosmetic
+                ))
+
+            for row in data:
+                item_data = EwItem(id_item=row[0])
+                item_data.item_props["adorned"] = 'false'
+                item_data.id_owner = target_data.id_user
+                item_data.persist()
+
+            ewutils.logMsg('Transferred {} cosmetic items.'.format(len(data)))
+
+            if source_data.weapon >= 0:
+                weapons_held = inventory(
+                    id_user=target_data.id_user,
+                    id_server=target_data.id_server,
+                    item_type_filter=ewcfg.it_weapon
+                )
+
+                if len(weapons_held) <= target_data.get_weapon_capacity():
+                    give_item(id_user=target_data.id_user, id_server=target_data.id_server, id_item=source_data.weapon)
+
+        except:
+            ewutils.logMsg("Failed to loot items from user {}".format(source_data.id_user))
 
 
 """
-	Check how many items are in a given district or player's inventory
+    Check how many items are in a given district or player's inventory
 """
 
 
 def get_inventory_size(owner = None, id_server = None):
     if owner != None and id_server != None:
-        try:
-            items_in_poi = bknd_core.execute_sql_query("SELECT {id_item} FROM items WHERE {id_owner} = %s AND {id_server} = %s".format(
-                id_item=ewcfg.col_id_item,
-                id_owner=ewcfg.col_id_user,
-                id_server=ewcfg.col_id_server
-            ), (
-                owner,
-                id_server
-            ))
+        # Get data from cache if possible
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache is not False:
+            target_items = item_cache.find_entries(criteria = {"id_owner": owner, "id_server": id_server})
+            return len(target_items)
 
-            return len(items_in_poi)
+        else:
+            try:
+                items_in_poi = bknd_core.execute_sql_query("SELECT {id_item} FROM items WHERE {id_owner} = %s AND {id_server} = %s".format(
+                    id_item=ewcfg.col_id_item,
+                    id_owner=ewcfg.col_id_user,
+                    id_server=ewcfg.col_id_server
+                ), (
+                    owner,
+                    id_server
+                ))
 
-        except:
-            return 0
+                return len(items_in_poi)
+
+            except:
+                return 0
     else:
         return 0
 
 
 """
-	Get a list of items for the specified player.
+    Get a list of items for the specified player.
 
-	Specify an item_type_filter to get only those items. Be careful: This is
-	inserted into SQL without validation/sanitation.
+    Specify an item_type_filter to get only those items. Be careful: This is
+    inserted into SQL without validation/sanitation.
 """
 
 
@@ -489,6 +591,36 @@ def inventory(
         item_sorting_method = None,
 ):
     items = []
+
+    # Grab the cache if it exists
+    item_cache = bknd_core.get_cache(obj_type = "EwItem")
+    if (item_cache is not False) and (id_server is not None):
+        # Setup criteria
+        criteria = {}
+        if id_user is not None: criteria.update({"id_owner": id_user})
+        if id_server is not None: criteria.update({"id_server": id_server})
+        if item_type_filter is not None: criteria.update({"item_type": item_type_filter})
+
+        found_items = item_cache.find_entries(criteria=criteria)
+
+        # Give a quantity to each item
+        for item_data in found_items:
+            items.append(item_data)
+
+            # Calculate quantity and set it for the object, cant wait for this to cause a major bug
+            quantity = 1
+            if item_data.get('stack_max') > 0:
+                quantity = item_data.get('stack_size')
+
+            item_data.update({'quantity': quantity})
+
+        # Sort the list by type if demanded, otherwise by id
+        if item_sorting_method == "type":
+            items.sort(key = lambda i: i.get("item_type"))
+        else:
+            items.sort(key=lambda i: i.get("id_item"))
+
+        return items
 
     try:
 
@@ -809,7 +941,7 @@ def inventory(
 
 
 """
-	Assign an existing item to a player
+    Assign an existing item to a player
 """
 
 
@@ -825,6 +957,7 @@ def give_item(
 
     if id_server is not None and id_user is not None and id_item is not None:
         item = EwItem(id_item=id_item)
+        item.id_owner = id_user
 
         # Ensure general limit implementation
         if ewutils.is_player_inventory(id_user, id_server):
@@ -847,6 +980,9 @@ def give_item(
                 id_item
             )
         )
+
+        bknd_core.cache_data(obj = item)
+
         remove_from_trades(id_item)
 
         # Reset the weapon's damage modifying stats
@@ -860,7 +996,7 @@ def give_item(
 
 
 """
-	Return false if a player's inventory is at or over capacity for a specific item type
+    Return false if a player's inventory is at or over capacity for a specific item type
 """
 
 
@@ -1125,3 +1261,29 @@ def get_weaponskill(user_data):
         weaponskill = 0
 
     return weaponskill
+
+
+""" Loads every item in the database into the cache. Returns true if successful, otherwise false. """
+
+def load_items_cache():
+    try:
+        # Grab the ID of every extant item
+        results = bknd_core.execute_sql_query("SELECT {id_item} FROM items".format(id_item=ewcfg.col_id_item))
+
+        # Initialize an EwItem for each returned ID
+        tracker = 0
+        for row in results:
+            tracker += 1
+            EwItem(id_item=row[0])
+            if tracker % 1000 == 0:
+                ewutils.logMsg("Loaded {} EwItems into cache.".format(tracker))
+
+        # Tell the client it didn't error out halfway
+        return True
+
+    except:
+        ewutils.logMsg("Failed to load all items from database into cache.")
+        return False
+
+
+bknd_core.cache_type_to_load_fn.update({"EwItem": load_items_cache})

--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -969,6 +969,7 @@ def give_item(
             )
 
             if len(other_items) >= ewcfg.generic_inv_limit:
+                del other_items
                 return False
 
         bknd_core.execute_sql_query(
@@ -1066,6 +1067,10 @@ def find_item(item_search = None, id_user = None, id_server = None, item_type_fi
                 break
             if item_sought == None and item_search in item_name:
                 item_sought = item
+
+        # Trust me just this once, this was necessary. use createall to make a huge item store and snag or scavenge
+        # Open task manager at look at memory usage after ratelimiting the bot. It's insane
+        del items
 
     return item_sought
 

--- a/ew/backend/player.py
+++ b/ew/backend/player.py
@@ -28,7 +28,13 @@ class EwPlayer:
             self.id_user = id_user
             self.id_server = id_server
 
+            #cache_result = bknd_core.get_cache_result(obj = self)
+
+            #if cache_result is not False:
+            #    self.__dict__ = cache_result
+
             try:
+
                 conn_info = bknd_core.databaseConnect()
                 conn = conn_info.get('conn')
                 cursor = conn.cursor()
@@ -48,6 +54,7 @@ class EwPlayer:
                     self.display_name = result[2]
                 elif id_server != None:
                     # Create a new database entry if the object is missing.
+                    ewutils.logMsg("Player {} was not found in database.".format(id_user))
                     cursor.execute("REPLACE INTO players({}, {}) VALUES(%s, %s)".format(
                         ewcfg.col_id_user,
                         ewcfg.col_id_server
@@ -57,6 +64,9 @@ class EwPlayer:
                     ))
 
                     conn.commit()
+
+                #bknd_core.cache_data(self)
+
             finally:
                 # Clean up the database handles.
                 cursor.close()
@@ -65,6 +75,8 @@ class EwPlayer:
     """ Save user data object to the database. """
 
     def persist(self):
+        #bknd_core.cache_data(obj = self)
+
         try:
             conn_info = bknd_core.databaseConnect()
             conn = conn_info.get('conn')

--- a/ew/backend/user.py
+++ b/ew/backend/user.py
@@ -485,16 +485,23 @@ class EwUserBase:
             if phone_data.item_props.get('active') == 'true':
                 return True
         """
-        data = bknd_core.execute_sql_query(
-            "SELECT it.* FROM items it INNER JOIN items_prop itp ON it.id_item = itp.id_item WHERE it.{id_user} = '%s' AND itp.{name} = %s AND itp.{value} = %s".format(
-                id_user=ewcfg.col_id_user,
-                id_item=ewcfg.col_id_item,
-                name=ewcfg.col_name,
-                value=ewcfg.col_value
-            ), (
-                self.id_user,
-                "gellphoneactive",
-                "true"
-            ))
+        # Use cache if it exists
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache is not False:
+            # Find all active gellphones belonging to the given user
+            data = item_cache.find_entries(criteria={"id_owner": self.id_user, "item_props": {"gellphoneactive": "true"}})
+
+        else:
+            data = bknd_core.execute_sql_query(
+                "SELECT it.* FROM items it INNER JOIN items_prop itp ON it.id_item = itp.id_item WHERE it.{id_user} = '%s' AND itp.{name} = %s AND itp.{value} = %s".format(
+                    id_user=ewcfg.col_id_user,
+                    id_item=ewcfg.col_id_item,
+                    name=ewcfg.col_name,
+                    value=ewcfg.col_value
+                ), (
+                    self.id_user,
+                    "gellphoneactive",
+                    "true"
+                ))
 
         return len(data) > 0

--- a/ew/cmd/apt/aptcmds.py
+++ b/ew/cmd/apt/aptcmds.py
@@ -1454,6 +1454,7 @@ async def remove_item(cmd):
                 item_type_filter=ewcfg.it_food
             )
             if len(food_items) >= usermodel.get_food_capacity():
+                del food_items
                 response = "You can't carry any more food."
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
         elif item_sought.get('item_type') == ewcfg.it_weapon:
@@ -1463,6 +1464,7 @@ async def remove_item(cmd):
                 item_type_filter=ewcfg.it_weapon
             )
             if len(wep_items) >= usermodel.get_weapon_capacity():
+                del wep_items
                 response = "You can't carry any more weapons."
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
@@ -1473,6 +1475,7 @@ async def remove_item(cmd):
                 item_type_filter=item_sought.get('item_type')
             )
             if len(other_items) >= ewcfg.generic_inv_limit:
+                del other_items
                 response = ewcfg.str_generic_inv_limit.format(item_sought.get('item_type'))
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 

--- a/ew/cmd/cmds/__init__.py
+++ b/ew/cmd/cmds/__init__.py
@@ -210,6 +210,12 @@ cmd_map = {
     ewcfg.cmd_shares: cmdcmds.shares,
     ewcfg.cmd_shares_alt1: cmdcmds.shares,
 
+    # Prints all cached data to the console
+    ewcfg.cmd_log_caches: cmdcmds.print_cache,
+
+    # Used for toggling of caches
+    ewcfg.cmd_toggle_caches: cmdcmds.toggle_cache,
+
 }
 
 dm_cmd_map = {

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -3765,3 +3765,75 @@ async def assign_status_effect(cmd = None, status_name = None, user_id = None, s
         user_data = EwUser(member=target)
         response = user_data.applyStatus(id_status=status_name, source=user_data.id_user, id_target=user_data.id_user)
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+
+
+async def print_cache(cmd):
+    if not cmd.message.author.guild_permissions.administrator:
+        return await cmd_utils.fake_failed_command(cmd)
+
+    typelog = "*{}*: Current cache types are: \n".format(cmd.message.author.display_name)
+    datalog = ""
+
+    for cache in bknd_core.caches:
+        typelog += "    {} with {} entries\n".format(cache.entry_type, len(cache.entries))
+        datalog += "\n{} Cache contains:\n".format(cache.entry_type)
+
+        entry_iter = 0
+        for entry_id, entry in cache.entries.items():
+            datalog += "    Identifier: {}, Data: {}\n".format(entry_id, entry)
+            entry_iter += 1
+            if entry_iter % 1000 == 0:
+                ewutils.logMsg("Building string for cache, this may take a bit...")
+
+    ewutils.logMsg(typelog)
+    ewutils.logMsg(datalog)
+
+
+async def toggle_cache(cmd):
+    if not cmd.message.author.guild_permissions.administrator:
+        return await cmd_utils.fake_failed_command(cmd)
+
+    response = "Command is used as follows: **!togglecache [1 or 0] [Name of cached object type]**"
+    # Ensure correct token count
+    if len(cmd.tokens) == 3:
+        # Dont break if they pass incorrect arguments
+        try:
+            # Extract arguments
+            desired_status = int(cmd.tokens[1])
+            target_cache = cmd.tokens[2]
+
+            # If they want the cache enabled
+            if desired_status:
+                # If the cache is allowed and not already enabled, initialize it
+                if (target_cache in ewcfg.cacheable_types) and (target_cache not in bknd_core.enabled_caches):
+                    bknd_core.enabled_caches.append(target_cache)
+                    response = "Caching of {}s has been enabled.\n".format(target_cache)
+
+                    bknd_core.ObjCache(ew_obj_type=target_cache)
+                    response += "{} cache has been initialized.\n".format(target_cache)
+                # If the cache is already enabled, tell them
+                elif (target_cache in ewcfg.cacheable_types):
+                    response = "Caching of {}s was already enabled.\n".format(target_cache)
+                # Dont allow caching on non-configured types
+                else:
+                    response = "Caching of {}s is disabled in cfg. Cannot be enabled.\n".format(target_cache)
+
+            else:
+                # disable if it is enabled
+                if target_cache in bknd_core.enabled_caches:
+                    bknd_core.enabled_caches.remove(target_cache)
+                    response = "Caching of {}s has been disabled.\n".format(target_cache)
+
+                # remove the object from the list and delete it
+                for potential_victim in bknd_core.caches:
+                    if potential_victim.entry_type == target_cache:
+                        bknd_core.caches.remove(potential_victim)
+                        del potential_victim
+                        response += "{} cache has been deleted.\n".format(target_cache)
+
+        # Uh-oh, someone used the command wrong. teach them how
+        except ValueError:
+            response = "Command failed to convert str to int."
+            response += " Structure of command is !togglecache (1 for on or 0 for off) (name of object type)."
+
+    await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))

--- a/ew/cmd/cosmeticitem/cosmeticcmds.py
+++ b/ew/cmd/cosmeticitem/cosmeticcmds.py
@@ -577,18 +577,36 @@ async def balance_cosmetics(cmd):
         id_cosmetic = cmd.tokens[1]
 
         try:
-            data = bknd_core.execute_sql_query(
-                "SELECT {id_item}, {item_type}, {col_soulbound}, {col_stack_max}, {col_stack_size} FROM items WHERE {id_server} = {server_id} AND {item_type} = '{type_item}'".format(
-                    id_item=ewcfg.col_id_item,
-                    item_type=ewcfg.col_item_type,
-                    col_soulbound=ewcfg.col_soulbound,
-                    col_stack_max=ewcfg.col_stack_max,
-                    col_stack_size=ewcfg.col_stack_size,
-                    id_server=ewcfg.col_id_server,
+            # Pull info from the cache if items are being cached
+            item_cache = bknd_core.get_cache(obj_type = "EwItem")
+            if item_cache is not False:
+                # find all cosmetics for the target server
+                server_cosmetic_data = item_cache.find_entries(criteria={"id_server": cmd.guild.id, "item_type": ewcfg.it_cosmetic})
 
-                    server_id=cmd.guild.id,
-                    type_item=ewcfg.it_cosmetic
-                ))
+                # format the results the same way the sql query would
+                data = list(map(lambda dat: [
+                    dat.get("id_item"),
+                    dat.get("item_type"),
+                    dat.get("soulbound"),
+                    dat.get("stack_max"),
+                    dat.get("stack_size")
+                ], server_cosmetic_data))
+                if len(data) == 0:
+                    data = None
+
+            else:
+                data = bknd_core.execute_sql_query(
+                    "SELECT {id_item}, {item_type}, {col_soulbound}, {col_stack_max}, {col_stack_size} FROM items WHERE {id_server} = {server_id} AND {item_type} = '{type_item}'".format(
+                        id_item=ewcfg.col_id_item,
+                        item_type=ewcfg.col_item_type,
+                        col_soulbound=ewcfg.col_soulbound,
+                        col_stack_max=ewcfg.col_stack_max,
+                        col_stack_size=ewcfg.col_stack_size,
+                        id_server=ewcfg.col_id_server,
+
+                        server_id=cmd.guild.id,
+                        type_item=ewcfg.it_cosmetic
+                    ))
 
             if data != None:
                 for row in data:

--- a/ew/cmd/faction/factioncmds.py
+++ b/ew/cmd/faction/factioncmds.py
@@ -107,7 +107,7 @@ async def store(cmd):
         else:
             response = "{} which item? (check **!inventory**)".format(cmd.tokens[0])
 
-    await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
 
 """retrieve items from a communal chest in your gang base"""
@@ -139,6 +139,7 @@ async def take(cmd):
             )
 
             if len(food_items) >= user_data.get_food_capacity():
+                del food_items
                 response = "You can't carry any more food items."
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
@@ -150,9 +151,11 @@ async def take(cmd):
             )
 
             if user_data.life_state == ewcfg.life_state_corpse:
+                del weapons_held
                 response = "Ghosts can't hold weapons."
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
             elif len(weapons_held) >= user_data.get_weapon_capacity():
+                del weapons_held
                 response = "You can't carry any more weapons."
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
@@ -163,6 +166,7 @@ async def take(cmd):
                 item_type_filter=item_sought.get('item_type')
             )
             if len(other_items) >= ewcfg.generic_inv_limit:
+                del other_items
                 response = ewcfg.str_generic_inv_limit.format(item_sought.get('item_type'))
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
@@ -170,10 +174,12 @@ async def take(cmd):
 
         response = "You retrieve a {} from the community chest.".format(item_sought.get("name"))
 
+        del item_sought
+
     else:
         if item_search:
             response = "There isn't one here."
         else:
             response = "{} which item? (check **{}**)".format(cmd.tokens[0], ewcfg.cmd_communitychest)
 
-    await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))

--- a/ew/cmd/item/__init__.py
+++ b/ew/cmd/item/__init__.py
@@ -61,6 +61,7 @@ cmd_map = {
     ewcfg.cmd_forgemasterpoudrin: itemcmds.forge_master_poudrin,
     ewcfg.cmd_createitem: itemcmds.create_item,
     ewcfg.cmd_createmulti: itemcmds.create_multi,
+    ewcfg.cmd_createall: itemcmds.create_all,
 
     ewcfg.cmd_manualsoulbind: itemcmds.manual_soulbind,
 

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -3,6 +3,7 @@ import random
 import re
 import sys
 import time
+from copy import copy, deepcopy
 
 import discord
 
@@ -189,69 +190,122 @@ async def squeeze(cmd):
 """
 
 
+inv_channel_ids = []
+
+
 async def inventory_print(cmd):
-    community_chest = False
-    can_message_user = True
-    item_type = None
+    # Setup basic variables
+    target_channel = cmd.message.channel
+    target_inventory = cmd.message.author.id
+    is_player_inventory = True
+    targeting_dms = False
 
-    inventory_source = cmd.message.author.id
-
+    # Retrieve indirect data
     player = EwPlayer(id_user=cmd.message.author.id)
+    user_data = EwUser(id_user=player.id_user, id_server=player.id_server)
+    poi_data = poi_static.id_to_poi.get(user_data.poi)
 
-    user_data = EwUser(id_user=cmd.message.author.id, id_server=player.id_server)
-    poi = poi_static.id_to_poi.get(user_data.poi)
+    # Note if this is in dms or not, so dms don't get formatted
+    if isinstance(cmd.message.channel, discord.DMChannel) and cmd.message.channel.recipient.id == cmd.message.author.id:
+        targeting_dms = True
+
+    # Check if it's a chest or not
     if cmd.tokens[0].lower() == ewcfg.cmd_communitychest:
-        if poi.community_chest == None:
-            response = "There is no community chest here."
-            return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-        elif cmd.message.channel.name != poi.channel:
-            response = "You can't see the community chest from here."
-            return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-        community_chest = True
-        can_message_user = False
-        inventory_source = poi.community_chest
 
+        # Stop now if there's no community chest
+        if poi_data.community_chest is None:
+            resp_txt = "There is no community chest here."
+            response = fe_utils.formatMessage(cmd.message.author, resp_txt) if not targeting_dms else resp_txt
+
+            return await fe_utils.send_message(cmd.client, target_channel, response)
+
+        # Ensure they are checking chests in the poi channel or their dms
+        if (not targeting_dms) and (target_channel.name != poi_data.channel):
+                resp_txt = "You can't see the community chest from here."
+                response = fe_utils.formatMessage(cmd.message.author, resp_txt) if not targeting_dms else resp_txt
+
+                return await fe_utils.send_message(cmd.client, target_channel, response)
+
+        # Mark as search for chest
+        is_player_inventory = False
+        target_inventory = poi_data.community_chest
+
+    else:
+        # Ensure the inventory response in sent in dms, in case they requested it from in-server
+        target_channel = cmd.message.author
+        targeting_dms = True
+
+    # Don't interrupt if there is already an inventory printing in that channel
+    if target_channel.id in inv_channel_ids:
+        resp_txt = "Let the last inventory finish, prick."
+        response = fe_utils.formatMessage(cmd.message.author, resp_txt) if not targeting_dms else resp_txt
+
+        return await fe_utils.send_message(cmd.client, target_channel, response)
+
+    # Check if the user has the bot blocked from dms, by dming them of course
+    if targeting_dms:
+        try:
+            resp_txt = "__You are holding:__" if is_player_inventory else "__The community chest contains:__"
+            await fe_utils.send_message(cmd.client, target_channel, resp_txt)
+        except:
+            # you can only tell them to unblock you if the channel they sent it through isn't their dms
+            if cmd.message.channel.id != cmd.message.author.id:
+                resp_txt = "You'll have to allow Endless War to send you DMs to check your inventory!"
+                response = fe_utils.formatMessage(cmd.message.author, resp_txt)
+                return await fe_utils.send_message(cmd.client, cmd.message.channel, response)
+
+    # All checks passed, let other prints know this channel is busy until the response is sent
+    inv_channel_ids.append(target_channel.id)
+
+    # Set default formatting and filtering parameters
     sort_by_type = False
     sort_by_name = False
     sort_by_id = False
 
     stacking = False
     search = False
-    stacked_message_list = []
-    stacked_item_map = {}
+    item_type = None
 
+    # Set new parameters if given
     if cmd.tokens_count > 1:
-        token_list = cmd.tokens[1:]
-        lower_token_list = []
-        for token in token_list:
-            token = token.lower()
-            lower_token_list.append(token)
+        # standardize case
+        lower_token_list = list(map(lambda tok: tok.lower(), cmd.tokens))
 
+        # Sort by type
         if 'type' in lower_token_list:
             sort_by_type = True
+        # Sort by name
         elif 'name' in lower_token_list:
             sort_by_name = True
+        # Sort by id
         elif 'id' in lower_token_list:
             sort_by_id = True
 
+        # Stack items of same name
         if 'stack' in lower_token_list:
             stacking = True
 
+        # Filter to general items
         if 'general' in lower_token_list:
             item_type = ewcfg.it_item
 
+        # Filter to Weapon items
         if 'weapon' in lower_token_list:
             item_type = ewcfg.it_weapon
 
+        # Filter to furniture items
         if 'furniture' in lower_token_list:
             item_type = ewcfg.it_furniture
 
+        # Filter to cosmetic items
         if 'cosmetic' in lower_token_list:
             item_type = ewcfg.it_cosmetic
 
+        # Filter to food items
         if 'food' in lower_token_list:
             item_type = ewcfg.it_food
 
+        # Search for a particular item. Ignore formatting parameters
         if 'search' in lower_token_list:
             stacking = False
             sort_by_id = False
@@ -259,80 +313,79 @@ async def inventory_print(cmd):
             sort_by_type = False
             search = True
 
+    # Finally, actually grab the inventory
     if sort_by_id:
         items = bknd_item.inventory(
-            id_user=inventory_source,
-            id_server=player.id_server,
+            id_user=target_inventory,
+            id_server=user_data.id_server,
             item_sorting_method='id',
             item_type_filter=item_type
         )
     elif sort_by_type:
         items = bknd_item.inventory(
-            id_user=inventory_source,
-            id_server=player.id_server,
+            id_user=target_inventory,
+            id_server=user_data.id_server,
             item_sorting_method='type',
             item_type_filter=item_type
         )
     elif search == True:
         items = itm_utils.find_item_all(
             item_search=ewutils.flattenTokenListToString(cmd.tokens[2:]),
-            id_server=player.id_server,
-            id_user=inventory_source,
+            id_server=user_data.id_server,
+            id_user=target_inventory,
             exact_search=False,
             search_names=True
         )
     else:
         items = bknd_item.inventory(
-            id_user=inventory_source,
-            id_server=player.id_server,
+            id_user=target_inventory,
+            id_server=user_data.id_server,
             item_type_filter=item_type
         )
 
-    if community_chest:
-        if len(items) == 0:
-            response = "The community chest is empty."
-        else:
-            response = "__The community chest contains:__"
-    else:
-        if len(items) == 0:
-            response = "You don't have anything."
-        else:
-            response = "__You are holding:__"
+    # Strip unnecessary data
+    items = list(map(lambda dat: {
+        "id_item": dat.get("id_item"),
+        "quantity": dat.get("quantity"),
+        "name": dat.get("name"),
+        "soulbound": dat.get("soulbound"),
+        "item_type": dat.get("item_type")
+    }, items))
 
-    msg_handle = None
-    try:
-        if can_message_user:
-            msg_handle = await fe_utils.send_message(cmd.client, cmd.message.author, response)
-    except discord.errors.Forbidden:
-        response = "You'll have to allow Endless War to send you DMs to check your inventory!"
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-    except:
-        can_message_user = False
-
-    if msg_handle is None:
-        can_message_user = False
-
-    if not can_message_user:
-        await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-
+    # sort by name if requested
     if sort_by_name:
         items = sorted(items, key=lambda item: item.get('name').lower())
 
+    # Setup a response container so the item data can get nuked ASAP, regardless of messages getting ratelimited
+    resp_ctn = fe_utils.EwResponseContainer(client=cmd.client, id_server=cmd.guild.id)
+
+    # Chests get to have the special empty response if they arent checked in dms, invs just cant be checked elsewhere
+    if not targeting_dms:
+        # Generate first message
+        if len(items) == 0:
+            response = fe_utils.formatMessage(cmd.message.author, "The community chest is empty.")
+        else:
+            response = fe_utils.formatMessage(cmd.message.author, "__The community chest contains:__")
+
+        # set it to be sent
+        resp_ctn.add_channel_response(target_channel, response)
+
     if len(items) > 0:
 
+        # Set variable defaults
+        stacked_item_map = {}
         response = ""
         current_type = ""
 
         for item in items:
-            id_item = item.get('id_item')
-            quantity = item.get('quantity')
 
             if not stacking:
+                # Generate the item's line in the response based on the specified formatting
                 response_part = "\n{id_item}: {soulbound_style}{name}{soulbound_style}{quantity}".format(
                     id_item=item.get('id_item'),
                     name=item.get('name'),
                     soulbound_style=("**" if item.get('soulbound') else ""),
-                    quantity=(" x{:,}".format(quantity) if (quantity > 1) else "")
+                    quantity=(" x{:,}".format(item.get("quantity")) if (item.get("quantity") > 1) else "")
                 )
 
                 # Print item type labels if sorting by type and showing a new type of items
@@ -340,20 +393,20 @@ async def inventory_print(cmd):
                     if current_type != item.get('item_type'):
                         current_type = item.get('item_type')
                         response_part = "\n**=={}==**".format(current_type.upper()) + response_part
-            else:
 
-                item_name = item.get('name')
-                if item_name in stacked_item_map:
-                    stacked_item = stacked_item_map.get(item_name)
+            else:
+                # Add item quantity to existing stack
+                if item.get('name') in stacked_item_map:
+                    stacked_item = stacked_item_map.get(item.get("name"))
                     stacked_item['quantity'] += item.get('quantity')
+                # Create stack for new item name
                 else:
-                    stacked_item_map[item_name] = item
+                    stacked_item_map[item.get("name")] = item
 
             if not stacking and len(response) + len(response_part) > 1492:
-                if can_message_user:
-                    await fe_utils.send_message(cmd.client, cmd.message.author, response)
-                else:
-                    await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+                # Format the response if necessary and add to the container
+                response = fe_utils.formatMessage(cmd.message.author, response) if not targeting_dms else response
+                resp_ctn.add_channel_response(target_channel, response)
 
                 response = ""
 
@@ -361,17 +414,24 @@ async def inventory_print(cmd):
                 response += response_part
 
         if stacking:
+            # Setup variables
             current_type = ""
             item_names = stacked_item_map.keys()
+
+            # Sort the names if necessary
             if sort_by_name:
                 item_names = sorted(item_names)
+
+            # iterate through all stacks
             for item_name in item_names:
+                # Get the stack's item data
                 item = stacked_item_map.get(item_name)
-                quantity = item.get('quantity')
+
+                # Generate the stack's line in the response
                 response_part = "\n{soulbound_style}{name}{soulbound_style}{quantity}".format(
                     name=item.get('name'),
                     soulbound_style=("**" if item.get('soulbound') else ""),
-                    quantity=(" **x{:,}**".format(quantity) if (quantity > 0) else "")
+                    quantity=(" **x{:,}**".format(item.get("quantity")) if (item.get("quantity") > 0) else "")
                 )
 
                 # Print item type labels if sorting by type and showing a different type of items
@@ -380,19 +440,30 @@ async def inventory_print(cmd):
                         current_type = item.get('item_type')
                         response_part = "\n**=={}==**".format(current_type.upper()) + response_part
 
+                # If the message is getting too long to send
                 if len(response) + len(response_part) > 1492:
-                    if can_message_user:
-                        await fe_utils.send_message(cmd.client, cmd.message.author, response)
-                    else:
-                        await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+                    # Add it to the responses, and start a new one
+                    # Format the response if necessary and add to the container
+                    response = fe_utils.formatMessage(cmd.message.author, response) if not targeting_dms else response
+                    resp_ctn.add_channel_response(target_channel, response)
 
                     response = ""
+
+                # Add the generated line to the response
                 response += response_part
 
-        if can_message_user:
-            await fe_utils.send_message(cmd.client, cmd.message.author, response)
-        else:
-            await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+        # Now that we have the responses, get the data out of memory
+        del items
+
+        # Format the response if necessary and add to the container
+        response = fe_utils.formatMessage(cmd.message.author, response) if not targeting_dms else response
+        resp_ctn.add_channel_response(target_channel, response)
+
+    # Send the response(s) then remove the target channel from the list of places already receiving inventories
+    await resp_ctn.post()
+    inv_channel_ids.remove(target_channel.id)
+
+    return
 
 
 """

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -459,6 +459,12 @@ async def inventory_print(cmd):
         response = fe_utils.formatMessage(cmd.message.author, response) if not targeting_dms else response
         resp_ctn.add_channel_response(target_channel, response)
 
+    else:
+        resp_txt = "Nothing."
+        response = fe_utils.formatMessage(cmd.message.author, resp_txt) if not targeting_dms else resp_txt
+        resp_ctn.add_channel_response(target_channel, response)
+
+
     # Send the response(s) then remove the target channel from the list of places already receiving inventories
     await resp_ctn.post()
     inv_channel_ids.remove(target_channel.id)

--- a/ew/cmd/item/itemutils.py
+++ b/ew/cmd/item/itemutils.py
@@ -1,3 +1,6 @@
+import sys
+
+from ew.backend import core as bknd_core
 from ew.backend import item as bknd_item
 from ew.backend.item import EwItem
 from ew.static import cfg as ewcfg

--- a/ew/cmd/juviecmd/juviecmds.py
+++ b/ew/cmd/juviecmd/juviecmds.py
@@ -829,12 +829,13 @@ async def scavenge(cmd):
 
             user_data.persist()
 
-            if not response == "":
-                await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-
             # gangsters don't need their roles updated
             if user_data.life_state == ewcfg.life_state_juvenile:
                 await ewrolemgr.updateRoles(client=cmd.client, member=cmd.message.author)
+
+            if not response == "":
+                return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+
     else:
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You'll find no slime here, this place has been picked clean. Head into the city to try and scavenge some slime."))
 

--- a/ew/cmd/move/movecmds.py
+++ b/ew/cmd/move/movecmds.py
@@ -1175,6 +1175,13 @@ async def flush_subzones(cmd):
 
         used_mother_district = mother_districts[0]
 
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache is not False:
+            targets_data = item_cache.find_entries(criteria={"id_owner": subzone, "id_server": cmd.guild.id})
+            for itm_dat in targets_data:
+                itm_dat.update({"id_owner": used_mother_district})
+                item_cache.set_entry(data=itm_dat)
+
         bknd_core.execute_sql_query("UPDATE items SET {id_owner} = %s WHERE {id_owner} = %s AND {id_server} = %s".format(
             id_owner=ewcfg.col_id_user,
             id_server=ewcfg.col_id_server
@@ -1212,6 +1219,13 @@ async def flush_streets(cmd):
                 user_data.persist()
                 member = cmd.guild.get_member(player)
                 await ewrolemgr.updateRoles(client=cmd.client, member=member)
+
+            item_cache = bknd_core.get_cache(obj_type = "EwItem")
+            if item_cache is not False:
+                targets_data = item_cache.find_entries(criteria={"id_owner": poi.id_poi, "id_server": cmd.guild.id})
+                for itm_dat in targets_data:
+                    itm_dat.update({"id_owner": poi.father_district})
+                    item_cache.set_entry(data=itm_dat)
 
             bknd_core.execute_sql_query("UPDATE items SET {id_owner} = %s WHERE {id_owner} = %s AND {id_server} = %s".format(
                 id_owner=ewcfg.col_id_user,

--- a/ew/cmd/move/moveutils.py
+++ b/ew/cmd/move/moveutils.py
@@ -1,7 +1,7 @@
 import math
 import random
 
-from ew.backend import core as bknd_core
+from ew.backend import core as bknd_core, item as bknd_item
 from ew.backend.item import EwItem
 from ew.backend.mutation import EwMutation
 from ew.backend.player import EwPlayer
@@ -190,20 +190,12 @@ def get_slimeoids_resp(id_server, poi):
 def get_random_prank_item(user_data, district_data):
     response = ""
 
-    items_in_poi = bknd_core.execute_sql_query(
-        "SELECT {id_item} FROM items WHERE {id_owner} = %s AND {id_server} = %s".format(
-            id_item=ewcfg.col_id_item,
-            id_owner=ewcfg.col_id_user,
-            id_server=ewcfg.col_id_server
-        ), (
-            user_data.poi,
-            district_data.id_server
-        ))
+    items_in_poi = bknd_item.inventory(id_user=user_data.poi, id_server=district_data.id_server)
 
     prank_items = []
 
     for item in items_in_poi:
-        id_item = item[0]
+        id_item = item.get("id_item")
         possible_prank_item = EwItem(id_item=id_item)
 
         context = possible_prank_item.item_props.get('context')

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -1243,7 +1243,11 @@ async def annoint(cmd):
 
             user_data.persist()
 
-            response = "You place your weapon atop the poudrin and annoint it with slime. It is now known as {}!\n\nThe name draws you closer to your weapon. The poudrin was destroyed in the process.".format(annoint_name)
+            naming_text = "It is now known as {}!\n\nThe name draws you closer to your weapon. ".format(annoint_name)
+            if annoint_name == "" or annoint_name is None:
+                naming_text = ""
+
+            response = "You place your weapon atop the poudrin and annoint it with slime. {}The poudrin was destroyed in the process.".format(naming_text)
 
     # Send the response to the player.
     await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -1142,6 +1142,7 @@ cmd_create = cmd_prefix + 'create'
 cmd_forgemasterpoudrin = cmd_prefix + 'forgemasterpoudrin'
 cmd_createitem = cmd_prefix + 'createitem'
 cmd_createmulti = cmd_prefix + 'createmulti'
+cmd_createall = cmd_prefix + 'createall'
 cmd_manualsoulbind = cmd_prefix + 'soulbind'
 cmd_editprops = cmd_prefix + 'editprops'
 cmd_setslime = cmd_prefix + 'setslime'
@@ -1496,6 +1497,8 @@ cmd_display_states = cmd_prefix + 'displaystates'
 cmd_press_button = cmd_prefix + 'press'
 cmd_call_elevator = cmd_prefix + 'callelevator'
 cmd_addstatuseffect = cmd_prefix + 'addstatuseffect'
+cmd_log_caches = cmd_prefix + 'cache'
+cmd_toggle_caches = cmd_prefix + 'togglecache'
 # SLIMERNALIA
 cmd_festivity = cmd_prefix + 'festivity'
 
@@ -3145,6 +3148,8 @@ durability_items = [
     item_id_gaiaseedpack_steelbeans,
     item_id_gaiaseedpack_aushucks
 ]
+
+all_item_ids = []
 
 vendor_dojo = "Dojo"
 
@@ -5754,6 +5759,29 @@ def set_client(cl):
 
     return client_ref
 
+
+"""
+    Default settings for the cache
+"""
+
+
+cacheable_types = ["EwItem"]
+
+autoload_types = ["EwItem"]
+
+obj_type_to_identifiers = {
+    "EwItem": [{"id_item", "id_entry"}],
+    # "EwPlayer": [{"id_user", "id_entry"}],
+    # "EwUser": [
+    #    {"id_user", "id_entry"},
+    #    {"id_server"}
+    # ],
+}
+
+obj_type_to_nested_props = {
+    "EwItem": ["item_props"],
+    # "EwEnemy": ["enemy_props"],
+}
 
 # scream = ""
 # for i in range(1, 10000):

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -5788,21 +5788,17 @@ obj_type_to_nested_props = {
 #     scream += "A"
 #     
 # print(scream)
-try:
-    from ew.cmd import debug as ewdebug
-except:
-    from ew.cmd import debug_dummy as ewdebug
-debugroom = ewdebug.debugroom
-debugroom_short = ewdebug.debugroom_short
-debugpiers = ewdebug.debugpiers
-debugfish_response = ewdebug.debugfish_response
-debugfish_goal = ewdebug.debugfish_goal
-cmd_debug1 = cmd_prefix + ewdebug.cmd_debug1
-cmd_debug2 = cmd_prefix + ewdebug.cmd_debug2
-cmd_debug3 = cmd_prefix + ewdebug.cmd_debug3
-cmd_debug4 = cmd_prefix + ewdebug.cmd_debug4
-# debug5 = ewdebug.debug5
-cmd_debug6 = cmd_prefix + ewdebug.cmd_debug6
-cmd_debug7 = cmd_prefix + ewdebug.cmd_debug7
-cmd_debug8 = cmd_prefix + ewdebug.cmd_debug8
-cmd_debug9 = cmd_prefix + ewdebug.cmd_debug9
+debugroom = None
+debugroom_short = None
+debugpiers = None
+debugfish_response = None
+debugfish_goal = None
+cmd_debug1 = None
+cmd_debug2 = None
+cmd_debug3 = None
+cmd_debug4 = None
+# debug5 = None
+cmd_debug6 = None
+cmd_debug7 = None
+cmd_debug8 = None
+cmd_debug9 = None

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -2465,6 +2465,13 @@ class EwUser(EwUserBase):
                 ewutils.weaponskills_clear(id_server=self.id_server, id_user=self.id_user, weaponskill=ewcfg.weaponskill_max_onrevive)
 
             try:
+                item_cache = bknd_core.get_cache(obj_type = "EwItem")
+                if item_cache is not False:
+                    tgt_itms = item_cache.find_entries(criteria={"item_props": {"preserved": self.id_user}})
+                    for itm_dat in tgt_itms:
+                        itm_dat.get("item_props").pop("preserved")
+                        item_cache.set_entry(data=itm_dat)
+
                 bknd_core.execute_sql_query(
                     "DELETE FROM items_prop WHERE {} = %s AND  {} = %s".format(
                         ewcfg.col_name,
@@ -3045,6 +3052,21 @@ class EwUser(EwUserBase):
         return bknd_item.get_freshness(self)
 
     def get_festivity(self):
+        # Use cache if available
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
+        if item_cache is not False:
+            # Get all user furniture id'd as a sigil
+            sigils = item_cache.find_entries(criteria={
+                "id_owner": self.id_user,
+                "item_type": ewcfg.it_furniture,
+                "id_server": self.id_server,
+                "item_props": {"id_furniture": ewcfg.item_id_sigillaria},
+            })
+
+            # return the sum of festivity props and 1000 per sigil
+            return self.festivity + self.festivity_from_slimecoin + (len(sigils)*1000)
+
+
         data = bknd_core.execute_sql_query(
             "SELECT {festivity} + COALESCE(sigillaria, 0) + {festivity_from_slimecoin} FROM users " \
             "LEFT JOIN (SELECT {id_user}, {id_server}, COUNT(*) * 1000 as sigillaria FROM items INNER JOIN items_prop ON items.{id_item} = items_prop.{id_item} " \

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -5,6 +5,9 @@ import re
 import string
 import time
 
+from sys import getsizeof, stderr
+from itertools import chain
+
 from ..backend import core as bknd_core
 from ..static import cfg as ewcfg
 from ..static import mutations as static_mutations
@@ -711,6 +714,39 @@ def get_slimernalia_kingpin(server):
 
 # Get the player with the most festivity
 def get_most_festive(server):
+    # Use the cache if it is enabled
+    item_cache = bknd_core.get_cache(obj_type = "EwItem")
+    if item_cache is not False:
+        # get a list of [id, festivitysum] for all users in server
+        dat = bknd_core.execute_sql_query("SELECT {id_user}, FLOOR({festivity}) + FLOOR({festivity_from_slimecoin}) FROM users WHERE {id_server} = %s".format(
+            id_user = ewcfg.col_id_user,
+            id_server = ewcfg.col_id_server,
+
+            festivity = ewcfg.col_festivity,
+            festivity_from_slimecoin = ewcfg.col_festivity_from_slimecoin,
+        ), (
+            server.id
+        ))
+
+        # iterate through all users in the server
+        for row in dat:
+            # Get all user furniture id'd as a sigil
+            sigils = item_cache.find_entries(criteria={
+                "id_owner": row[0],
+                "item_type": ewcfg.it_furniture,
+                "id_server": server.id,
+                "item_props": {"id_furniture": ewcfg.item_id_sigillaria},
+            })
+
+            # add 1000 festivity to the user's sum per sigil
+            row[1] += (len(sigils) * 1000)
+
+        # Sort the rows by the second index in each row, highest first
+        dat.sort(key=lambda row: row[1], reverse=True)
+
+        return dat[0][0]
+
+
     data = bknd_core.execute_sql_query(
         "SELECT users.{id_user}, FLOOR({festivity}) + COALESCE(sigillaria, 0) + FLOOR({festivity_from_slimecoin}) as total_festivity FROM users " \
         "LEFT JOIN (SELECT {id_user}, {id_server}, COUNT(*) * 1000 as sigillaria FROM items INNER JOIN items_prop ON items.{id_item} = items_prop.{id_item} WHERE {name} = %s AND {value} = %s GROUP BY items.{id_user}, items.{id_server}) f on users.{id_user} = f.{id_user} AND users.{id_server} = f.{id_server} " \
@@ -870,3 +906,37 @@ def weather_txt(market_data):
 
     response += "It is currently {}{} in NLACakaNM.{}".format(displaytime, ampm, (' ' + flair))
     return response
+
+
+
+def total_size(o, verbose=False):
+    """ Returns the approximate memory footprint an object and all of its contents.
+    Automatically finds the contents of the following builtin containers and
+    their subclasses:  tuple, list, dict, set and frozenset.
+    """
+    dict_handler = lambda d: chain.from_iterable(d.items())
+    all_handlers = {tuple: iter,
+                    list: iter,
+                    dict: dict_handler,
+                    set: iter,
+                    frozenset: iter,
+                   }
+    seen = set()                      # track which object id's have already been seen
+    default_size = getsizeof(0)       # estimate sizeof object without __sizeof__
+
+    def sizeof(o):
+        if id(o) in seen:       # do not double count the same object
+            return 0
+        seen.add(id(o))
+        s = getsizeof(o, default_size)
+
+        if verbose:
+            print(s, type(o), repr(o), file=stderr)
+
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                break
+        return s
+
+    return sizeof(o)

--- a/ew/utils/cosmeticitem.py
+++ b/ew/utils/cosmeticitem.py
@@ -6,8 +6,21 @@ from ew.utils import core as ewutils
 
 
 async def dedorn_all_costumes():
-    costumes = bknd_core.execute_sql_query("SELECT id_item FROM items_prop WHERE name = 'context' AND value = 'costume' AND id_item IN (SELECT id_item FROM items_prop WHERE (name = 'adorned' OR name = 'slimeoid') AND value = 'true')")
     costume_count = 0
+    # Grab costumes from the cache if enabled
+    item_cache = bknd_core.get_cache(obj_type = "EwItem")
+    if item_cache is not False:
+        # separate search criteria for adorned or slimeoided
+        p1 = {"context": "costume", "adorned": "true"}
+        p2 = {"context": "costume", "slimeoid": "true"}
+        # compile both results
+        costumes_data = item_cache.find_entries(criteria={"item_props": p1})
+        costumes_data += item_cache.find_entries(criteria={"item_props": p2})
+
+        # Build a list that'll be handled in the same way
+        costumes = list(map(lambda dat: dat.get("id_item"), costumes_data))
+    else:
+        costumes = bknd_core.execute_sql_query("SELECT id_item FROM items_prop WHERE name = 'context' AND value = 'costume' AND id_item IN (SELECT id_item FROM items_prop WHERE (name = 'adorned' OR name = 'slimeoid') AND value = 'true')")
 
     for costume_id in costumes:
         costume_item = EwItem(id_item=costume_id)

--- a/ew/utils/item.py
+++ b/ew/utils/item.py
@@ -408,20 +408,11 @@ def item_lootrandom(user_data):
     response = ""
 
     try:
-
-        items_in_poi = bknd_core.execute_sql_query("SELECT {id_item} FROM items WHERE {id_owner} = %s AND {id_server} = %s".format(
-            id_item=ewcfg.col_id_item,
-            id_owner=ewcfg.col_id_user,
-            id_server=ewcfg.col_id_server
-        ), (
-            user_data.poi,
-            user_data.id_server
-        ))
+        # find_item() uses the inventory() function anyway, so why have custom sql here followed by what you're avoiding
+        items_in_poi = bknd_item.inventory(id_user=user_data.poi, id_server=user_data.id_server)
 
         if len(items_in_poi) > 0:
-            id_item = random.choice(items_in_poi)[0]
-
-            item_sought = bknd_item.find_item(item_search=str(id_item), id_user=user_data.poi, id_server=user_data.id_server)
+            item_sought = random.choice(items_in_poi)
 
             response += "You found a {}!".format(item_sought.get('name'))
 
@@ -433,7 +424,7 @@ def item_lootrandom(user_data):
                         metric=ewcfg.stat_poudrins_looted,
                         n=1
                     )
-                bknd_item.give_item(id_user=user_data.id_user, id_server=user_data.id_server, id_item=id_item)
+                bknd_item.give_item(id_user=user_data.id_user, id_server=user_data.id_server, id_item=item_sought.get("id_item"))
             else:
                 response += " But you couldn't carry any more {}s, so you tossed it back.".format(item_sought.get('item_type'))
 

--- a/ew/utils/prank.py
+++ b/ew/utils/prank.py
@@ -31,31 +31,25 @@ async def activate_trap_items(district, id_server, id_user):
         return
 
     try:
-        conn_info = bknd_core.databaseConnect()
-        conn = conn_info.get('conn')
-        cursor = conn.cursor()
-
         district_channel_name = poi_static.id_to_poi.get(district).channel
-
         client = ewutils.get_client()
-
         server = client.get_guild(id_server)
-
         member = server.get_member(id_user)
-
         district_channel = fe_utils.get_channel(server=server, channel_name=district_channel_name)
-
         searched_id = district + '_trap'
+        item_cache = bknd_core.get_cache(obj_type = "EwItem")
 
-        cursor.execute("SELECT id_item, id_user FROM items WHERE id_user = %s AND id_server = %s".format(
-            id_item=ewcfg.col_id_item,
-            id_user=ewcfg.col_id_user
-        ), (
-            searched_id,
-            id_server,
-        ))
-
-        traps = cursor.fetchall()
+        if item_cache is not False:
+            traps = item_cache.find_entries(criteria={"id_owner": searched_id, "id_server": id_server})
+            traps = list(map(lambda dat: [dat.get("id_item"), dat.get("id_owner")], traps))
+        else:
+            traps = bknd_core.execute_sql_query("SELECT id_item, id_user FROM items WHERE id_user = %s AND id_server = %s".format(
+                id_item=ewcfg.col_id_item,
+                id_user=ewcfg.col_id_user
+            ), (
+                searched_id,
+                id_server,
+            ))
 
         if len(traps) == 0:
             # print('no traps')

--- a/ew/utils/prank.py
+++ b/ew/utils/prank.py
@@ -91,9 +91,7 @@ async def activate_trap_items(district, id_server, id_user):
         bknd_item.item_delete(trap_id_item)
 
     finally:
-        # Clean up the database handles.
-        cursor.close()
-        bknd_core.databaseClose(conn_info)
+        pass
     await fe_utils.send_message(client, district_channel, fe_utils.formatMessage(member, response))
 
 


### PR DESCRIPTION
Items are now retrieved from and saved to a cache if available
 - Added !createall <number of copies> <target mention> for admin use to create a variable number of all in game items
 - Added !togglecache <0 or 1> <object type, ex: EwItem> to disable the cache if there are any issues, and reload the cache if something is directly changed in the database by hand
 - Only one chest/inventory print can be active in any particular channel
 - Chests can now be viewed from DMs, in case someone is trolling and spamming a full print when a user just needs to search
 - Rowdy Roughchest and other massive inventories will no longer freeze the entire bot when used.
 - Items now generate their name themselves instead of relying on the inventory function to figure it out