### PR TITLE
Added !verifycache for admin use

### DIFF
--- a/ew/cmd/cmds/__init__.py
+++ b/ew/cmd/cmds/__init__.py
@@ -216,6 +216,9 @@ cmd_map = {
     # Used for toggling of caches
     ewcfg.cmd_toggle_caches: cmdcmds.toggle_cache,
 
+    # Verify that the cache is functional
+    ewcfg.cmd_verify_cache: cmdcmds.verify_cache,
+
 }
 
 dm_cmd_map = {

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -3853,3 +3853,23 @@ async def toggle_cache(cmd):
             response += " Structure of command is !togglecache (1 for on or 0 for off) (name of object type)."
 
     await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+
+
+async def verify_cache(cmd):
+    # Only allow admins to use this
+    if not cmd.message.author.guild_permissions.administrator:
+        return await cmd_utils.fake_failed_command(cmd)
+    
+    # Get items how find_item would
+    server_id = cmd.guild.id
+    server_items = bknd_item.inventory(id_server=server_id)
+
+    # Iterate through all items
+    for item_data in server_items:
+        # log the ID and data if it fails where find_item would
+        try:
+            flat_name = ewutils.flattenTokenListToString(item_data.get("name"))
+        except:
+            ewutils.logMsg("Item {}'s name failed flattening. Data: \n{}".format(item_data.get("id_item"), item_data))
+
+    return

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -1499,6 +1499,7 @@ cmd_call_elevator = cmd_prefix + 'callelevator'
 cmd_addstatuseffect = cmd_prefix + 'addstatuseffect'
 cmd_log_caches = cmd_prefix + 'cache'
 cmd_toggle_caches = cmd_prefix + 'togglecache'
+cmd_verify_cache = cmd_prefix + 'verifycache'
 # SLIMERNALIA
 cmd_festivity = cmd_prefix + 'festivity'
 


### PR DESCRIPTION
!verifycache will get all items in the server it is called in through the same inventory function as find_item, and try flattenTokenListToString with the item's name, and on exception will log the item's id and cached data.