### PR TITLE
Slimernalia Updates

### DIFF
--- a/ew/cmd/casino/casinocmds.py
+++ b/ew/cmd/casino/casinocmds.py
@@ -23,7 +23,8 @@ from .casinoutils import get_skat_play
 from .casinoutils import printcard
 from .casinoutils import printhand
 from .casinoutils import skat_putback
-from .casinoutils import slimecoin_to_festivity
+from .casinoutils import payout
+from .casinoutils import collect_bet
 
 # Map containing user IDs and the last time in UTC seconds since the pachinko
 # machine was used.
@@ -176,32 +177,13 @@ async def pachinko(cmd):
             response = "You lack the higher brain functions required to {}.".format(cmd.tokens[0])
             return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
+        value = 1
         if currency_used == ewcfg.currency_slimecoin:
             value = ewcfg.slimes_perpachinko
-
-            if value > user_data.slimecoin:
-                response = "You don't have enough SlimeCoin to play. You need {} but only have {}.".format(value, user_data.slimecoin)
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-            # subtract costs
-            user_data.change_slimecoin(n=-value, coinsource=ewcfg.coinsource_casino)
-        # SLIMERNALIA
-            user_data.festivity_from_slimecoin += slimecoin_to_festivity(value, user_data.festivity_from_slimecoin)
-
-        else:
+        elif currency_used == ewcfg.currency_slime:
             value = ewcfg.slimes_perpachinko * ewcfg.slimecoin_exchangerate
-
-            if user_data.life_state == ewcfg.life_state_corpse:
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_machine))
-
-            if value > user_data.slimes:
-                response = "You don't have enough slime to play. You need {} but only have {}.".format(value, user_data.slimes)
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-            # subtract costs
-            user_data.change_slimes(n=-value, source=ewcfg.source_casino)
-        # SLIMERNALIA
-            user_data.festivity += value
+        
+        await collect_bet(cmd, resp, value, user_data, currency_used)
 
         user_data.persist()
 
@@ -243,17 +225,8 @@ async def pachinko(cmd):
             response += "\n\n**You won {:,} {currency}!**".format(winnings, currency=currency_used)
         else:
             response += "\n\nYou lost your {}.".format(currency_used)
-
-        # add winnings
-        if currency_used == ewcfg.currency_slimecoin:
-            user_data.change_slimecoin(n=winnings, coinsource=ewcfg.coinsource_casino)
-        elif currency_used == ewcfg.currency_slime:
-            levelup_response = user_data.change_slimes(n=winnings, source=ewcfg.source_casino)
-
-            if levelup_response != "":
-                response += "\n\n" + levelup_response
-
-        user_data.persist()
+        
+        response += payout(winnings, value, user_data, currency_used)
 
         # Allow the player to pachinko again now that we're done.
         last_pachinkoed_times[cmd.message.author.id] = 0
@@ -267,6 +240,7 @@ async def pachinko(cmd):
 
 async def craps(cmd):
     time_now = int(time.time())
+    resp = await cmd_utils.start(cmd=cmd)
 
     user_data = EwUser(member=cmd.message.author)
 
@@ -294,7 +268,7 @@ async def craps(cmd):
 
         if district_data.is_degraded():
             response = "{} has been degraded by shamblers. You can't {} here anymore.".format(poi.str_name, cmd.tokens[0])
-            return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+            return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
         last_crapsed_times[cmd.message.author.id] = time_now
         value = None
         winnings = 0
@@ -306,19 +280,10 @@ async def craps(cmd):
 
         if value != None:
             user_data = EwUser(member=cmd.message.author)
-            if user_data.life_state == ewcfg.life_state_shambler:
-                response = "You lack the higher brain functions required to {}.".format(cmd.tokens[0])
-                return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+            
+            await collect_bet(cmd, resp, value, user_data, currency_used)
 
-            if currency_used == ewcfg.currency_slimecoin:
-                if value == -1:
-                    value = user_data.slimecoin
-
-                elif value > user_data.slimecoin:
-                    response = "You don't have that much SlimeCoin to bet with."
-                    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-
-            elif currency_used == ewcfg.currency_soul:
+            if currency_used == ewcfg.currency_soul:
                 if cmd.mentions_count > 0:
                     correct_soul = 0
                     user_inv = bknd_item.inventory(id_server=user_data.id_server, id_user=user_data.id_user)
@@ -329,28 +294,17 @@ async def craps(cmd):
                                 correct_soul = item.id_item
                     if correct_soul == 0:
                         response = "You don't have that soul."
-                        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+                        return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
                     else:
                         bknd_item.give_item(id_item=correct_soul, id_user="casinosouls_wait", id_server=user_data.id_server)
                         soul_id = correct_soul
                 elif user_data.has_soul == 0:
                     response = "You don't have a soul to bet."
-                    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
                 else:
                     soul_id = item_utils.surrendersoul(receiver=user_data.id_user, giver=user_data.id_user, id_server=user_data.id_server)
                     bknd_item.give_item(id_item=soul_id, id_user="casinosouls_wait", id_server=user_data.id_server)
                     user_data = EwUser(member=cmd.message.author)
-
-            else:
-                if user_data.life_state == ewcfg.life_state_corpse:
-                    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_dealer))
-
-                if value == -1:
-                    value = user_data.slimes
-
-                elif value > user_data.slimes:
-                    response = "You don't have that much slime to bet with."
-                    return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
             roll1 = random.randint(1, 6)
             roll2 = random.randint(1, 6)
@@ -380,26 +334,14 @@ async def craps(cmd):
                 if currency_used == ewcfg.currency_soul:
                     bknd_item.give_item(id_item=soul_id, id_user="casinosouls", id_server=cmd.guild.id)
 
-            # add winnings/subtract losses
-            if currency_used == ewcfg.currency_slimecoin:
-                user_data.change_slimecoin(n=winnings - value, coinsource=ewcfg.coinsource_casino)
-            # SLIMERNALIA
-                user_data.festivity_from_slimecoin += slimecoin_to_festivity(value, user_data.festivity_from_slimecoin)
-            elif currency_used == ewcfg.currency_slime:
-                levelup_response = user_data.change_slimes(n=winnings - value, source=ewcfg.source_casino)
-
-                if levelup_response != "":
-                    response += "\n\n" + levelup_response
-
-            # SLIMERNALIA
-                user_data.festivity += value
+            response += payout(winnings, value, user_data, currency_used)
 
             user_data.persist()
         else:
             response = "Specify how much {} you will wager.".format(currency_used)
 
     # Send the response to the player.
-    await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+    await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
     # gangsters don't need their roles updated
     if user_data.life_state == ewcfg.life_state_juvenile:
         await ewrolemgr.updateRoles(client=cmd.client, member=cmd.message.author)
@@ -443,34 +385,13 @@ async def slots(cmd):
             response = "You lack the higher brain functions required to {}.".format(cmd.tokens[0])
             return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
+        value = 1
         if currency_used == ewcfg.currency_slimecoin:
             value = ewcfg.slimes_perslot
-
-            if value > user_data.slimecoin:
-                response = "You don't have enough SlimeCoin. You need {} but only have {}.".format(value, user_data.slimecoin)
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-            # subtract costs
-            user_data.change_slimecoin(n=-value, coinsource=ewcfg.coinsource_casino)
-
-        # SLIMERNALIA
-            user_data.festivity_from_slimecoin += slimecoin_to_festivity(value, user_data.festivity_from_slimecoin)
-
-        else:
+        elif currency_used == ewcfg.currency_slime:
             value = ewcfg.slimes_perslot * ewcfg.slimecoin_exchangerate
-
-            if user_data.life_state == ewcfg.life_state_corpse:
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_machine))
-
-            if value > user_data.slimes:
-                response = "You don't have enough slime. You need {} but only have {}.".format(value, user_data.slimes)
-                return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-            # subtract costs
-            user_data.change_slimes(n=-value, source=ewcfg.source_casino)
-
-        # SLIMERNALIA
-            user_data.festivity += value
+        
+        await collect_bet(cmd, resp, value, user_data, currency_used)
 
         user_data.persist()
 
@@ -637,42 +558,14 @@ async def roulette(cmd):
                 response = "You lack the higher brain functions required to {}.".format(cmd.tokens[0])
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
-            if currency_used == ewcfg.currency_slimecoin:
-                if value == -1:
-                    value = user_data.slimecoin
-
-                if value > user_data.slimecoin:
-                    response = "You don't have enough SlimeCoin."
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-                # subtract costs
-                user_data.change_slimecoin(n=-value, coinsource=ewcfg.coinsource_casino)
-            # SLIMERNALIA
-                user_data.festivity_from_slimecoin += slimecoin_to_festivity(value, user_data.festivity_from_slimecoin)
-
-            elif currency_used == ewcfg.currency_soul:
-                pass
-            else:
-                if user_data.life_state == ewcfg.life_state_corpse:
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_dealer))
-
-                if value == -1:
-                    value = user_data.slimes
-
-                if value > user_data.slimes:
-                    response = "You don't have enough slime."
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-                # subtract costs
-                user_data.change_slimes(n=-value, source=ewcfg.source_casino)
-            # SLIMERNALIA
-                user_data.festivity += value
-
             if len(bet) == 0:
                 response = "You need to say what you're betting on. Options are: {}\n{}board.png".format(ewutils.formatNiceList(names=all_bets), img_base)
             elif bet not in all_bets:
                 response = "The dealer didn't understand your wager. Options are: {}\n{}board.png".format(ewutils.formatNiceList(names=all_bets), img_base)
             else:
+                # Handle all "regular bets", including slime / slimecoin
+                await collect_bet(cmd, resp, value, user_data, currency_used)
+
                 if currency_used == ewcfg.currency_soul:
                     if cmd.mentions_count > 0:
                         correct_soul = 0
@@ -775,16 +668,7 @@ async def roulette(cmd):
 
                 # add winnings
                 user_data = EwUser(member=cmd.message.author)
-
-                if currency_used == ewcfg.currency_slimecoin:
-                    user_data.change_slimecoin(n=winnings, coinsource=ewcfg.coinsource_casino)
-                elif currency_used == ewcfg.currency_slime:
-                    levelup_response = user_data.change_slimes(n=winnings, source=ewcfg.source_casino)
-
-                    if levelup_response != "":
-                        response += "\n\n" + levelup_response
-
-                user_data.persist()
+                response += payout(winnings, value, user_data, currency_used)
         else:
             response = "Specify how much {} you will wager.".format(currency_used)
 
@@ -850,38 +734,6 @@ async def baccarat(cmd):
                 response = "You lack the higher brain functions required to {}.".format(cmd.tokens[0])
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
-            if currency_used == ewcfg.currency_slimecoin:
-                if value == -1:
-                    value = user_data.slimecoin
-
-                if value > user_data.slimecoin:
-                    response = "You don't have enough SlimeCoin."
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-                # subtract costs
-                user_data.change_slimecoin(n=-value, coinsource=ewcfg.coinsource_casino)
-            # SLIMERNALIA
-                user_data.festivity_from_slimecoin += slimecoin_to_festivity(value, user_data.festivity_from_slimecoin)
-
-            elif currency_used == ewcfg.currency_soul:
-                pass
-            else:
-                if user_data.life_state == ewcfg.life_state_corpse:
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_dealer))
-
-                if value == -1:
-                    value = user_data.slimes
-
-                if value > user_data.slimes:
-                    response = "You don't have enough slime."
-                    return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
-
-                # subtract costs
-                user_data.change_slimes(n=-value, source=ewcfg.source_casino)
-
-            # SLIMERNALIA
-                user_data.festivity += value
-
             if len(bet) == 0:
                 response = "You must specify what hand you are betting on. Options are {}.".format(ewutils.formatNiceList(names=all_bets), img_base)
                 await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
@@ -893,6 +745,8 @@ async def baccarat(cmd):
                 await asyncio.sleep(1)
 
             else:
+                await collect_bet(cmd, resp, value, user_data, currency_used)
+                
                 if currency_used == ewcfg.currency_soul:
                     if cmd.mentions_count > 0:
                         correct_soul = 0
@@ -1433,13 +1287,7 @@ async def baccarat(cmd):
 
                 # add winnings
                 user_data = EwUser(member=cmd.message.author)
-                if currency_used == ewcfg.currency_slimecoin:
-                    user_data.change_slimecoin(n=winnings, coinsource=ewcfg.coinsource_casino)
-                elif currency_used == ewcfg.currency_slime:
-                    levelup_response = user_data.change_slimes(n=winnings, source=ewcfg.source_casino)
-
-                    if levelup_response != "":
-                        response += "\n\n" + levelup_response
+                response += payout(winnings, value, user_data, currency_used)
 
                 user_data.persist()
                 await fe_utils.edit_message(cmd.client, resp_f, fe_utils.formatMessage(cmd.message.author, response))
@@ -2177,8 +2025,8 @@ async def russian_roulette(cmd):
             challenger = EwUser(member = author)
             challengee = EwUser(member = member)
 
-            challengee.festivity += challengee.slimes
-            challenger.festivity += challenger.slimes
+            challengee.festivity += round((challenger.slimes / 100000) + 50)
+            challenger.festivity += round((challengee.slimes / 100000) + 50)
 
             challenger.persist()
             challengee.persist()

--- a/ew/cmd/casino/casinoutils.py
+++ b/ew/cmd/casino/casinoutils.py
@@ -15,7 +15,13 @@ def payout(winnings, bet, user_data, currency_used):
         
         # SLIMERNALIA
         if ewcfg.slimernalia_active:
-            user_data.festivity += calc_payout_festivity(winnings)
+            lifestate_mod = 0.5
+            
+            # Gangsters and ghosts are bad at slimernalia gambling
+            if user_data.life_state == ewcfg.life_state_juvenile:
+                lifestate_mod = 1
+            
+            user_data.festivity += (calc_payout_festivity(winnings) * lifestate_mod)
 
     user_data.persist()
     # print("Paid out a value of {} to {}.".format(winnings, user_data.id_user))

--- a/ew/cmd/casino/casinoutils.py
+++ b/ew/cmd/casino/casinoutils.py
@@ -2,6 +2,63 @@ import math
 import shlex
 
 from ew.static import cfg as ewcfg
+from ew.utils import frontend as fe_utils
+
+def payout(winnings, bet, user_data, currency_used):
+    response = ""
+    if currency_used == ewcfg.currency_slimecoin:
+        user_data.change_slimecoin(n=winnings, coinsource=ewcfg.coinsource_casino)
+    elif currency_used == ewcfg.currency_slime:
+        levelup_response = user_data.change_slimes(n=winnings, source=ewcfg.source_casino)
+        if levelup_response != "":
+            response = "\n\n" + levelup_response
+        
+        # SLIMERNALIA
+        if ewcfg.slimernalia_active:
+            user_data.festivity += calc_payout_festivity(winnings)
+
+    user_data.persist()
+    # print("Paid out a value of {} to {}.".format(winnings, user_data.id_user))
+    return response
+
+def calc_payout_festivity(value):
+    if value >= 1000:
+        return value / 1000
+    else:
+        return 1
+
+async def collect_bet(cmd, resp, value, user_data, currency_used):
+    response = ""
+    if currency_used == ewcfg.currency_slimecoin:
+        if value == -1:
+            value = user_data.slimecoin
+
+        if value > user_data.slimecoin:
+            response = "You don't have enough SlimeCoin for that bet."
+            return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
+
+        # subtract costs
+        user_data.change_slimecoin(n=-value, coinsource=ewcfg.coinsource_casino)
+    
+    elif currency_used == ewcfg.currency_slime:
+        if user_data.life_state == ewcfg.life_state_corpse:
+            return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, ewcfg.str_casino_negaslime_dealer))
+
+        if value == -1:
+            value = user_data.slimes
+
+        if value > user_data.slimes:
+            response = "You don't have enough slime for that bet."
+            return await fe_utils.edit_message(cmd.client, resp, fe_utils.formatMessage(cmd.message.author, response))
+
+        # Phoebus likes big bets and he cannot lie
+        if ewcfg.slimernalia_active and (value > ewcfg.phoebus_bet_floor):
+            user_data.festivity += value / 10000
+        
+        # subtract costs
+        user_data.change_slimes(n=-value, source=ewcfg.source_casino)
+    # print("Collected bet of {} from {}.".format(value, user_data.id_user))
+    return response
 
 
 def printcard(card):
@@ -292,13 +349,3 @@ def determine_trick_taker(trick, gametype, trump):
         else:
             ranks.append(100)
     return ranks.index(min(ranks))
-
-
-# Unused
-def slimecoin_to_festivity(value, festivity_old):
-    try:
-        old_value = 1.00044 ** festivity_old
-        festivity_new = math.log(old_value + value) / math.log(1.00044)
-    except:
-        festivity_new = math.log(9223372036854775807) / math.log(1.00044)
-    return festivity_new

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -2130,7 +2130,7 @@ async def wrap(cmd):
                 gift_expiry = float(item.item_props.get("time_expir"))
 
                 if gift_expiry <= time.time():
-                    bonus = ewcfg.festivity_expired_penalty
+                    bonus -= ewcfg.festivity_expired_penalty
 
                 bonus += (gift_hunger / 10) * ewcfg.festivity_gift_food
             # Furniture-specific bonuses
@@ -2147,6 +2147,10 @@ async def wrap(cmd):
                     bonus += ewcfg.festivity_patr_bonus
                 else:
                     bonus += ewcfg.festivity_othr_bonus
+            # Phoebus isn't so sure about anything else
+            else:
+                festivity_value -= ewcfg.festivity_generic_penality
+        
             # Generic bonus
             if item.item_props.get("item_message"):
                 bonus += ewcfg.festivity_scrawl_bonus

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -2101,6 +2101,60 @@ async def wrap(cmd):
 
             response = "You shroud your {} in {} and slap on a premade bow. Onto it, you attach a note containing the following text: '{}'.\nThis small act of kindness manages to endow you with Slimernalia spirit, if only a little.".format(item_sought.get('name'), paper_name, gift_address)
 
+            festivity_value = ewcfg.festivity_gift_base
+            bonus = 0
+            # Calculate the festivity value of the gift - this changes depending on the type of item wrapped
+            # Cosmetic-specific bonuses
+            if item.item_type == ewcfg.it_cosmetic:
+                gift_freshness = int(item.item_props.get("freshness"))
+
+                bonus += gift_freshness * ewcfg.festivity_gift_cosmetic                
+                if item.item_props.get("hue"):
+                    bonus += ewcfg.festivity_dye_bonus
+            # Weapon-specific bonuses
+            elif item.item_type == ewcfg.it_weapon:
+                gift_kills = int(item.item_props.get("totalkills"))
+                gift_type = item.item_props.get("weapon_type")
+                gift_wtype = static_weapons.weapon_map.get(gift_type)
+
+                if gift_wtype.acquisition == ewcfg.acquisition_smelting:
+                    bonus += ewcfg.festivity_smelt_bonus
+
+                bonus = gift_kills * ewcfg.festivity_gift_weapon
+                
+                if item.item_props.get("weapon_name"):
+                    bonus += ewcfg.festivity_name_bonus
+            # Food-specific bonuses
+            elif item.item_type == ewcfg.it_food:
+                gift_hunger = int(item.item_props.get("recover_hunger"))
+                gift_expiry = float(item.item_props.get("time_expir"))
+
+                if gift_expiry <= time.time():
+                    bonus = ewcfg.festivity_expired_penalty
+
+                bonus += (gift_hunger / 10) * ewcfg.festivity_gift_food
+            # Furniture-specific bonuses
+            elif item.item_type == ewcfg.it_furniture:
+                gift_rarity = item.item_props.get("rarity")
+                gift_acquisition = item.item_props.get('acquisition')
+
+                if gift_acquisition == ewcfg.acquisition_smelting:
+                    bonus += ewcfg.festivity_smelt_bonus
+
+                if gift_rarity == ewcfg.rarity_plebeian:
+                    bonus += ewcfg.festivity_pleb_bonus
+                elif gift_rarity == ewcfg.rarity_patrician:
+                    bonus += ewcfg.festivity_patr_bonus
+                else:
+                    bonus += ewcfg.festivity_othr_bonus
+            # Generic bonus
+            if item.item_props.get("item_message"):
+                bonus += ewcfg.festivity_scrawl_bonus
+
+            festivity_value += bonus
+
+            if festivity_value < 0: festivity_value = 1
+
             bknd_item.item_create(
                 id_user=cmd.message.author.id,
                 id_server=cmd.guild.id,
@@ -2112,13 +2166,17 @@ async def wrap(cmd):
                     'context': gift_address,
                     'acquisition': "{}".format(item_sought.get('id_item')),
                     # flag indicating if the gift has already been given once so as to not have people farming festivity through !giving
-                    'gifted': "false"
+                    'gifted': "false",
+                    'gift_value': festivity_value,
+                    'gifter_id': user_data.id_user,
+                    'gifter_server': user_data.id_server
                 }
             )
+
             bknd_item.give_item(id_item=item_sought.get('id_item'), id_user=str(cmd.message.author.id) + "gift", id_server=cmd.guild.id)
             bknd_item.item_delete(id_item=paper_item.id_item)
 
-            user_data.festivity += ewcfg.festivity_on_gift_wrapping
+            user_data.festivity += ewcfg.festivity_gift_wrap
 
             user_data.persist()
     else:

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -925,7 +925,7 @@ async def give(cmd):
             if item_data.item_props.get('id_item') == 'gift' and item_data.item_props.get("gifted") == "false":
                 item_data.item_props['gifted'] = "true"
                 item_data.persist()
-                user_data.festivity += ewcfg.festivity_on_gift_giving
+                user_data.festivity += int(item_data.item_props.get("gift_value"))
                 user_data.persist()
 
         # don't let people give others food when they shouldn't be able to carry more food items
@@ -1515,12 +1515,19 @@ async def unwrap(cmd):
                         gift_name_type = 'title'
 
                     gifted_item_name = gifted_item.item_props.get('{}'.format(gift_name_type))
+                    
+                    # Specifically for weapons, if the weapon doesn't have a name, then use it's type
+                    if (not gifted_item_name) and gifted_item.item_type == ewcfg.it_weapon:
+                        weapon_type = gifted_item.item_props.get("weapon_type")
+                        weapon_data = static_weapons.weapon_map.get(weapon_type)
+                        gifted_item_name = weapon_data.str_name
+                    
                     gifted_item_message = item.item_props.get('context')
 
                     if ewcfg.slimernalia_active:
-                        user_data = EwUser(member=cmd.message.author)
-                        user_data.festivity += ewcfg.festivity_on_gift_wrapping
-                        user_data.persist()
+                        giftee_data = EwUser(member=cmd.message.author)
+                        giftee_data.festivity += ewcfg.festivity_gift_wrap
+                        giftee_data.persist()
 
                     response = "You shred through the packaging formalities to reveal a {}!\nThere is a note attached: '{}'.".format(gifted_item_name, gifted_item_message)
                     bknd_item.item_delete(id_item=item_sought.get('id_item'))

--- a/ew/cmd/mutation/mutationcmds.py
+++ b/ew/cmd/mutation/mutationcmds.py
@@ -669,7 +669,7 @@ async def devour(cmd):
                 item_has_expired = float(getattr(item_obj, "time_expir", 0)) < time.time()
 
                 if item_has_expired and not (user_has_spoiled_appetite or item_is_non_perishable):
-                    response = "You realize that the food you were trying to eat is already spoiled. Ugh, not eating that."
+                    response = "You realize that the {} you were trying to eat is already spoiled. Ugh, not eating that.".format(item_sought.get('name'))
                     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
                 # ewitem.item_drop(food_item.id_item)
 

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -294,6 +294,9 @@ async def attack(cmd):
                 slimeoid_kill=slimeoid_kill
             ))
 
+            if ewcfg.slimernalia_active and attacker.life_state == ewcfg.life_state_juvenile:
+                attacker.festivity += ewcfg.festivity_kill_bonus
+            
             if attacker_slimeoid.life_state == ewcfg.slimeoid_state_active:
                 slimeoid_resp += "\n\n" + sl_static.brain_map.get(attacker_slimeoid.ai).str_kill.format(slimeoid_name=attacker_slimeoid.name)
 

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -2160,7 +2160,8 @@ trade_state_complete = 2
 
 # SLIMERNALIA
 festivity_on_gift_wrapping = 100
-festivity_on_gift_giving = 10000
+festivity_on_gift_giving = 1000
+phoebus_bet_floor = 1000000
 
 # Common strings.
 str_casino_closed = "The Casino only operates at night."

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -2177,7 +2177,8 @@ festivity_sigil_bonus = 1000 # The amount of festivity you gain per sigillaria
 
 festivity_kill_bonus = 500 # The  amount of festivity you gain upon killing someone
 
-festivity_expired_penalty = -2500 # Penalty if the food item you are giving has already expired
+festivity_expired_penalty = 2500 # Penalty if the food item you are giving has already expired
+festivity_generic_penality = 500 # Penality if the item is something generic
 
 phoebus_bet_floor = 1000000 # How high a slime bet needs to be to get the Phoebus' Blessing bonus
 

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -2172,6 +2172,10 @@ festivity_pleb_bonus = 10 # Bonus for plebian tier gifts
 festivity_patr_bonus = 100 # Bonus for patrician tier gifts
 festivity_othr_bonus = 300 # Bonus for any other tier gifts
 
+festivity_sigil_bonus = 1000 # The amount of festivity you gain per sigillaria
+
+festivity_kill_bonus = 500 # The  amount of festivity you gain upon killing someone
+
 festivity_expired_penalty = -2500 # Penalty if the food item you are giving has already expired
 
 phoebus_bet_floor = 1000000 # How high a slime bet needs to be to get the Phoebus' Blessing bonus

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -3,7 +3,7 @@
 
 
 
-version = "v4.012 doubledoublehalloween"
+version = "v4.013 neo slimernalia"
 
 dir_msgqueue = 'msgqueue'
 
@@ -2159,9 +2159,22 @@ trade_state_ongoing = 1
 trade_state_complete = 2
 
 # SLIMERNALIA
-festivity_on_gift_wrapping = 100
-festivity_on_gift_giving = 1000
-phoebus_bet_floor = 1000000
+festivity_gift_wrap = 100 # How much festivity is rewarded for wrapping / unwrapping a present
+festivity_gift_base = 1000 # How much festivity a basic gift is worth
+festivity_gift_food = 1 # How much festivity is given per ten points of hunger restored by the food
+festivity_gift_weapon = 100 # How much festivity is given per kill on a weapon
+festivity_gift_cosmetic = 10 # How much festivity is given per freshness on a cosmetic
+festivity_dye_bonus = 500 # Bonus for dyeing a gifted cosmetic
+festivity_scrawl_bonus = 100 # Bonus for scrawling on a gift
+festivity_name_bonus = 100 # Bonus for naming a weapon gift
+festivity_smelt_bonus = 500 # Bonus for gifting something handmade
+festivity_pleb_bonus = 10 # Bonus for plebian tier gifts
+festivity_patr_bonus = 100 # Bonus for patrician tier gifts
+festivity_othr_bonus = 300 # Bonus for any other tier gifts
+
+festivity_expired_penalty = -2500 # Penalty if the food item you are giving has already expired
+
+phoebus_bet_floor = 1000000 # How high a slime bet needs to be to get the Phoebus' Blessing bonus
 
 # Common strings.
 str_casino_closed = "The Casino only operates at night."

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -2627,7 +2627,7 @@ class EwUser(EwUserBase):
         user_has_spoiled_appetite = ewcfg.mutation_id_spoiledappetite in mutations
         item_has_expired = float(getattr(food_item, "time_expir", 0)) < time.time()
         if item_has_expired and not (user_has_spoiled_appetite or item_is_non_perishable):
-            response = "You realize that the food you were trying to eat is already spoiled. Ugh, not eating that."
+            response = "You realize that the {} you were trying to eat is already spoiled. Ugh, not eating that.".format(food_item.name)
         # ewitem.item_drop(food_item.id_item)
         else:
             hunger_restored = int(item_props['recover_hunger'])

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -2651,6 +2651,12 @@ class EwUser(EwUserBase):
             self.inebriation += int(item_props['inebriation'])
             if self.inebriation > 20:
                 self.inebriation = 20
+            
+            if ewcfg.slimernalia_active:
+                food_type = static_food.food_map.get(item_props.get("id_food"))
+                if food_type and food_type.acquisition == ewcfg.acquisition_smelting:
+                    print("added bonus festivity")
+                    self.festivity += 100
 
             try:
                 if item_props['id_food'] in ["coleslaw", "bloodcabbagecoleslaw"]:

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -740,8 +740,8 @@ def get_most_festive(server):
                 "item_props": {"id_furniture": ewcfg.item_id_sigillaria},
             })
 
-            # add 1000 festivity to the user's sum per sigil
-            row[1] += (len(sigils) * 1000)
+            # add festivity to the user's sum per sigil
+            row[1] += (len(sigils) * ewcfg.festivity_sigil_bonus)
             f_data.append(row)
         # Sort the rows by the second index in each row, highest first
         f_data.sort(key=lambda row: row[1], reverse=True)

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -718,7 +718,7 @@ def get_most_festive(server):
     item_cache = bknd_core.get_cache(obj_type = "EwItem")
     if item_cache is not False:
         # get a list of [id, festivitysum] for all users in server
-        data = bknd_core.execute_sql_query("SELECT {id_user}, FLOOR({festivity}) + FLOOR({festivity_from_slimecoin}) FROM users WHERE {id_server} = %s".format(
+        data = bknd_core.execute_sql_query("SELECT {id_user}, FLOOR({festivity}) + FLOOR({festivity_from_slimecoin}) FROM users WHERE {id_server} = %s AND (FLOOR({festivity}) + FLOOR({festivity_from_slimecoin})) >= 1".format(
             id_user = ewcfg.col_id_user,
             id_server = ewcfg.col_id_server,
 
@@ -745,28 +745,30 @@ def get_most_festive(server):
             f_data.append(row)
         # Sort the rows by the second index in each row, highest first
         f_data.sort(key=lambda row: row[1], reverse=True)
+        if f_data:
+            return f_data[0][0]
+        else:
+            return 1
 
-        return f_data[0][0]
+    else:
+        data = bknd_core.execute_sql_query(
+            "SELECT users.{id_user}, FLOOR({festivity}) + COALESCE(sigillaria, 0) + FLOOR({festivity_from_slimecoin}) as total_festivity FROM users " \
+            "LEFT JOIN (SELECT {id_user}, {id_server}, COUNT(*) * 1000 as sigillaria FROM items INNER JOIN items_prop ON items.{id_item} = items_prop.{id_item} WHERE {name} = %s AND {value} = %s GROUP BY items.{id_user}, items.{id_server}) f on users.{id_user} = f.{id_user} AND users.{id_server} = f.{id_server} " \
+            "WHERE users.{id_server} = %s ORDER BY total_festivity DESC LIMIT 1".format(
+                id_user=ewcfg.col_id_user,
+                id_server=ewcfg.col_id_server,
+                festivity=ewcfg.col_festivity,
+                festivity_from_slimecoin=ewcfg.col_festivity_from_slimecoin,
+                name=ewcfg.col_name,
+                value=ewcfg.col_value,
+                id_item=ewcfg.col_id_item,
+            ), (
+                "id_furniture",
+                ewcfg.item_id_sigillaria,
+                server.id,
+            ))
 
-
-    data = bknd_core.execute_sql_query(
-        "SELECT users.{id_user}, FLOOR({festivity}) + COALESCE(sigillaria, 0) + FLOOR({festivity_from_slimecoin}) as total_festivity FROM users " \
-        "LEFT JOIN (SELECT {id_user}, {id_server}, COUNT(*) * 1000 as sigillaria FROM items INNER JOIN items_prop ON items.{id_item} = items_prop.{id_item} WHERE {name} = %s AND {value} = %s GROUP BY items.{id_user}, items.{id_server}) f on users.{id_user} = f.{id_user} AND users.{id_server} = f.{id_server} " \
-        "WHERE users.{id_server} = %s ORDER BY total_festivity DESC LIMIT 1".format(
-            id_user=ewcfg.col_id_user,
-            id_server=ewcfg.col_id_server,
-            festivity=ewcfg.col_festivity,
-            festivity_from_slimecoin=ewcfg.col_festivity_from_slimecoin,
-            name=ewcfg.col_name,
-            value=ewcfg.col_value,
-            id_item=ewcfg.col_id_item,
-        ), (
-            "id_furniture",
-            ewcfg.item_id_sigillaria,
-            server.id,
-        ))
-
-    return data[0][0]
+        return data[0][0]
 
 
 """ Returns the latest value, so that short PvP timer actions don't shorten remaining PvP time. """

--- a/ew/utils/frontend.py
+++ b/ew/utils/frontend.py
@@ -500,6 +500,7 @@ async def update_slimernalia_kingpin(client, server):
     try:
         new_kingpin_member = server.get_member(new_kingpin.id_user)
         await ewrolemgr.updateRoles(client=client, member=new_kingpin_member)
+        print("New kingpin is {}".format(new_kingpin_member))
     except:
         ewutils.logMsg("Error adding kingpin of slimernalia role to user {} in server {}.".format(new_kingpin.id_user, server.id))
 


### PR DESCRIPTION
Patch Notes:

- Phoebus has had enough of this !slimecraps 0 bullshit, and has completely reworked the way festivity is gained! Gift giving, killing, eating handmade foods and slime gambling are great ways of getting festivity!
- When failing to !eat a rotten food, you'll now be told what food you failed to eat
- "Optimised" festivity code

Developer Notes:
- This update should be used in conjunction with a reset on festivity and festivity_from_slimecoin for all users
- Refactored gambling code
- Slimecoin gambling no longer gives festivity
- Slime gambling now calculates festivity using a / 1000 linear function instead of some heavily broken exponentials
- Slime bets above 1,000,000 reward a 10,000th of the bet as festivity as a bonus whether or not you win the bet
- Eating handmade (acquisition smelting) foods will give 100 festivity - this encourages players to grow and make juvie crops
- Gift festivity value now scales on a number of different factors, depending on the type of gift: Food gifts scale on the hunger restored, and take a penalty if the food is spoiled. Weapon gifts scale with kills and naming. Cosmetics scale with freshness and rarity as well as a bonus if they are dyed. All gifts will increase in value if they are !scrawled on. Furniture scales on rarity.
- Killing rewards a festivity bonus alongside sigillarias