### PR TITLE
!Give festivity exploit patch 💃🎁🧍(also !yoslimernalia thing)

### DIFF
--- a/client.py
+++ b/client.py
@@ -519,6 +519,7 @@ async def on_message(message):
 
     re_awoo = re.compile('.*![a]+[w]+o[o]+.*')
     re_moan = re.compile('.*![b]+[r]+[a]+[i]+[n]+[z]+.*')
+    re_yoslimernalia = re.compile('.*![y]+[o]+[s]+[l]+[i]+[m]+[e]+[r]+[n]+[a]+[l]+[i]+[a]+.*')
     re_measure = re.compile('!measure.*')
     
     # update the player's time_last_action which is used for kicking AFK players out of subzones
@@ -1044,6 +1045,8 @@ async def on_message(message):
             return await ewcmd.cmdcmds.cmd_howl(cmd_obj)
         elif re_moan.match(cmd):
             return await ewcmd.cmdcmds.cmd_moan(cmd_obj)
+        elif re_yoslimernalia.match(cmd) and ewcfg.slimernalia_active:
+            return await ewcmd.cmdcmds.yoslimernalia(cmd_obj)
         elif re_measure.match(cmd):
             return await ewcmd.cmdcmds.cockdraw(cmd_obj)
 
@@ -1053,7 +1056,7 @@ async def on_message(message):
             response = ""
 
             if mentions_count == 0:
-                response = 'Set who\'s role?'
+                response = 'Set whose role?'
             else:
                 roles_map = ewutils.getRoleMap(message.guild.roles)
                 role_target = tokens[1]
@@ -1202,6 +1205,15 @@ async def on_message(message):
             client=client,
             guild=message.guild
         ))
+    elif content_tolower.find(ewcfg.cmd_yoslimernalia) >= 0 or re_yoslimernalia.match(content_tolower):
+        if ewcfg.slimernalia_active:
+            return await ewcmd.cmdcmds.yoslimernalia(cmd_utils.EwCmd(
+                message=message,
+                client=client,
+                guild=message.guild
+            ))
+        else:
+            return
 
 
 @client.event

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -2062,7 +2062,7 @@ async def wrap(cmd):
 
     member = cmd.message.author
     user_data = EwUser(member=cmd.message.author)
-
+    
     if recipient_data.id_user == user_data.id_user:
         response = "C'mon man, you got friends, don't you? Try and give a gift to someone other than yourself."
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
@@ -2090,6 +2090,10 @@ async def wrap(cmd):
                 return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
         if item.soulbound:
             response = "It's a nice gesture, but trying to gift someone a Soulbound item is going a bit too far, don't you think?"
+        # Check if the item has been gifted before
+        elif item.item_props.get('gifted') == "true":
+            print("I am going to kill myself")
+            response = "Alas, regifting is considered a grave sin from Phoebus themselves. Enjoy your gift, or else. {}".format(ewcfg.emote_slimeheart)
         elif not bknd_item.check_inv_capacity(user_data=user_data, item_type=ewcfg.it_item):
             response = ewcfg.str_generic_inv_limit.format(ewcfg.it_item)
         else:
@@ -2100,6 +2104,10 @@ async def wrap(cmd):
             gift_desc = "A gift wrapped in {}. Wonder what's inside?\nThe front of the tag reads '{}'\nOn the back of the tag, an ID number reads **({})**.".format(paper_name, gift_address, item.id_item)
 
             response = "You shroud your {} in {} and slap on a premade bow. Onto it, you attach a note containing the following text: '{}'.\nThis small act of kindness manages to endow you with Slimernalia spirit, if only a little.".format(item_sought.get('name'), paper_name, gift_address)
+
+            # Make the gifted item marked as gifted so that it can't be regifted once it's gifted
+            item.item_props['gifted'] = "true"
+            item.persist()
 
             festivity_value = ewcfg.festivity_gift_base
             bonus = 0

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -913,6 +913,11 @@ async def give(cmd):
         response = "You must be in the same location as the person you want to gift your item to, bitch."
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
+    # Check if the player is giving an item to themselves
+    if user_data.id_user == recipient_data.id_user:
+        response = "You can't give yourself something you already have, headass. You literally **already have it.**"
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+
     item_sought = bknd_item.find_item(item_search=item_search, id_user=author.id, id_server=server.id)
 
     if item_sought:  # if an item was found
@@ -1526,7 +1531,9 @@ async def unwrap(cmd):
 
                     if ewcfg.slimernalia_active:
                         giftee_data = EwUser(member=cmd.message.author)
-                        giftee_data.festivity += ewcfg.festivity_gift_wrap
+                        # Make sure the player is not opening their own gift before applying festivity
+                        if giftee_data.id_user != item.item_props.get("gifter_id"):
+                            giftee_data.festivity += ewcfg.festivity_gift_wrap
                         giftee_data.persist()
 
                     response = "You shred through the packaging formalities to reveal a {}!\nThere is a note attached: '{}'.".format(gifted_item_name, gifted_item_message)


### PR DESCRIPTION
Changes !wrap so that items can only be !wrapped once ever. Regifting is BANNED.
Makes it so that you are unable to !give yourself items.
Makes it so that !unwrapping gifts you yourself made gives you 0 festivity.
Makes !yoslimernalia function like !awoo - typing any length variation of !yoslimernalia or using !yoslimernalia in the middle of a message will still trigger !yoslimernalia (request from Luca).

Uhhh in terms of the code:
!Wrapping an item now gives it the "gifted" prop once !unwrapped. Any items with the "gifted" prop are unable to be !wrapped.