### PR TITLE
Cache multi-update

### DIFF
--- a/ew/backend/core.py
+++ b/ew/backend/core.py
@@ -279,7 +279,6 @@ class ObjCache():
 
         # Figure out what to change
         for data in entries:
-            print(data)
             entry_id = self.get_data_id(data)
             old_data = self.entries.get(entry_id)
 
@@ -304,20 +303,24 @@ class ObjCache():
             # Compile Entry updates
             entries_update.update({entry_id: data})
 
-        print(index_removals)
-        print(index_additions)
         # Remove old index values
         for prop_name, index_data in index_removals.items():
             for index_val, ids_to_remove in index_data.items():
+                # We assume that the items are already properly indexed, that way if they aren't, this can warn us :)
                 list_to_edit = self.indexes.get(prop_name).get(index_val)
                 for removed_id in ids_to_remove:
                     list_to_edit.remove(removed_id)
 
         # add new index values
         for prop_name, index_data in index_additions.items():
+            # iterating through all property indexes, and all of the subsequent indexed values and their id lists
             for index_val, ids_to_add in index_data.items():
+                # Get the id list for the target prop and value, or make it if it doesnt exist
                 list_to_edit = self.indexes.get(prop_name).get(index_val)
-                list_to_edit += ids_to_add
+                if list_to_edit is None:
+                    self.indexes.get(prop_name).update({index_val: ids_to_add})
+                else:
+                    list_to_edit += ids_to_add
 
         # Update stored data
         self.entries.update(entries_update)

--- a/ew/backend/core.py
+++ b/ew/backend/core.py
@@ -259,7 +259,7 @@ class ObjCache():
                 if meets:
                     copied_matches.append(self.copy_entry(data))
 
-            return copied_matches
+        return copied_matches
 
     def bulk_set_entry(self, entries = None):
         """

--- a/ew/backend/core.py
+++ b/ew/backend/core.py
@@ -209,7 +209,7 @@ class ObjCache():
 
         if id_list != None:
             for id in id_list:
-                copied_matches.append(self.entries.get(id))
+                copied_matches.append(self.copy_entry(self.entries.get(id)))
 
         else:
             # Create list to search

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -2467,8 +2467,6 @@ class EwUser(EwUserBase):
                 ids_to_drop.extend(itm_utils.item_dropsome(id_server=self.id_server, id_user=self.id_user, item_type_filter=ewcfg.it_cosmetic, fraction=cosmetic_fraction, rigor=rigor))  # Drop a random fraction of your unadorned cosmetics on the ground.
                 # bknd_item.item_dedorn_cosmetics(id_server=self.id_server, id_user=self.id_user)  # Unadorn all of your adorned hats.
                 ids_to_drop.extend(itm_utils.die_dropall(user_data=self, item_type=ewcfg.it_relic, kill_method=cause))
-                  # Drop random fraction of your unequipped weapons on the ground.
-
 
                 ewutils.weaponskills_clear(id_server=self.id_server, id_user=self.id_user, weaponskill=ewcfg.weaponskill_max_onrevive)
 
@@ -2487,10 +2485,12 @@ class EwUser(EwUserBase):
                     ewutils.logMsg('Failed to drop items on death, {}.'.format(e))
 
                 item_cache = bknd_core.get_cache(obj_type="EwItem")
+                dropped_items_to_update = []
                 for id in ids_to_drop:
                     cache_item = item_cache.get_entry(unique_vals={"id_item": id})
                     cache_item.update({'id_owner':self.poi})
-                    item_cache.set_entry(data=cache_item)
+                    dropped_items_to_update.append(cache_item)
+                item_cache.bulk_set_entry(entries=dropped_items_to_update)
 
             try:
 

--- a/ew/utils/item.py
+++ b/ew/utils/item.py
@@ -1,6 +1,8 @@
 import collections
 import random
 import time
+import traceback
+import sys
 
 from . import core as ewutils
 from . import frontend as fe_utils
@@ -84,7 +86,7 @@ def item_dropsome(id_server = None, id_user = None, item_type_filter = None, fra
     # except:
     #	ewutils.logMsg('Failed to drop items for user with id {}'.format(id_user))
 
-def die_dropall( #drops all items unless they have been rigor mortissed
+def die_dropall( # returns a list of all item ids to drop
         user_data,
         item_type ,
         kill_method = '',
@@ -99,25 +101,51 @@ def die_dropall( #drops all items unless they have been rigor mortissed
 
     try:
         if kill_method != ewcfg.cause_suicide and item_type == ewcfg.it_relic:
-            result = bknd_core.execute_sql_query(
-                "select id_item from items WHERE id_user = %s AND id_server = %s and soulbound = 0 {}".format(
-                    type_filter), (
-                    user_data.id_user,
-                    user_data.id_server
-                ))
+            item_cache = bknd_core.get_cache(obj_type="EwItem")
+            if item_cache:
+                search_criteria = {
+                    'id_owner': user_data.id_user,
+                    'id_server': user_data.id_server,
+                    'soulbound': False
+                }
+                if item_type != '':
+                    search_criteria.update({'item_type': item_type})
+                result = item_cache.find_entries(criteria=search_criteria)
+                result = list(map(lambda dat: [dat.get('id_item')], result))
+            else:
+                result = bknd_core.execute_sql_query(
+                    "select id_item from items WHERE id_user = %s AND id_server = %s and soulbound = 0 {}".format(
+                        type_filter), (
+                        user_data.id_user,
+                        user_data.id_server
+                    ))
         else:
-            result =bknd_core.execute_sql_query( #this query excludes preserved items
-                "select it.id_item from items it left join items_prop ip on it.id_item = ip.id_item and ip.name = 'preserved' and ip.value = %s WHERE id_user = %s AND id_server = %s and soulbound = 0 and ip.name IS NULL {}".format(type_filter), (
-                    user_data.id_user,
-                    user_data.poi,
-                    user_data.id_user,
-                    user_data.id_server
-                ))
+            item_cache = bknd_core.get_cache(obj_type="EwItem")
+            if item_cache:
+                search_criteria = {
+                    'id_owner': user_data.id_user,
+                    'id_server': user_data.id_server,
+                    'soulbound': False,
+                    'item_props': {'preserved': user_data.id_user}
+                }
+                if item_type != '':
+                    search_criteria.update({'item_type': item_type})
+                result = item_cache.find_entries(criteria=search_criteria)
+                result = list(map(lambda dat: [dat.get('id_item')], result))
+            else:
+                result =bknd_core.execute_sql_query( #this query excludes preserved items
+                    "select it.id_item from items it left join items_prop ip on it.id_item = ip.id_item and ip.name = 'preserved' and ip.value = %s WHERE id_user = %s AND id_server = %s and soulbound = 0 and ip.name IS NULL {}".format(type_filter), (
+                        user_data.id_user,
+                        user_data.poi,
+                        user_data.id_user,
+                        user_data.id_server
+                    ))
         if result is not None:
             for id in result:
                 end_list.append(id[0])
     except:
         ewutils.logMsg('Failed to drop items for user with id {}'.format(user_data.id_user))
+        traceback.print_exc(file=sys.stdout)
     return end_list
 
 


### PR DESCRIPTION
 - Added bulk_set_entry to have allow the cache to be fed a list of items, and update as simultaneously as possible, though iterative set_entrys were barely slower so this was (kinda) pointless
 - Changed the relic dropping on death function to get ids from the cache rather than querying the sql
 - Changed .die to use the new bulk cache update function, down from .01 seconds for 525 items to .008. Basically just making sure the function works right before applying it to multistow
 - fixed an apparent bug in find_entries where the return clause was indented too far to run if fed a list of ids as opposed to criteria, and also fixed the lack of copying of data to be returned in that case