### PR TITLE
Krakacola alias fix

### DIFF
--- a/ew/static/food.py
+++ b/ew/static/food.py
@@ -1339,7 +1339,7 @@ food_list = [
     ),
     EwFood(
         id_food = "krakacolafuckenergy",
-        alias = ['dffu'],
+        alias = ['kcfu'],
         recover_hunger = 1200,
         price = 12000,
         str_name = "Kraka Kola FUCK ENERGY Drink",


### PR DESCRIPTION
Fixes the krakacola shortened alias because it used the same alias as drfucker (how did this never go noticed?)
Literally just changes two letters, not very exciting