### PR TITLE
fixed kp issue (better than zugs)

### DIFF
--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -439,7 +439,6 @@ faction_roles = [
     role_corpse,
     role_corpse_pvp,
     role_corpse_active,
-    role_kingpin,
     role_grandfoe,
     role_tutorial,
 ]

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -398,6 +398,10 @@ def get_faction(user_data=None, life_state=0, faction="") -> str:
 
     elif life_state == ewcfg.life_state_kingpin:
         faction_role = ewcfg.role_kingpin
+        if faction == ewcfg.faction_killers:
+            faction_role = ewcfg.role_copkiller
+        elif faction == ewcfg.faction_rowdys:
+            faction_role = ewcfg.role_rowdyfucker
 
     elif life_state == ewcfg.life_state_grandfoe:
         faction_role = ewcfg.role_grandfoe

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -415,26 +415,27 @@ def get_faction(user_data=None, life_state=0, faction="") -> str:
     return faction_role
 
 
-def get_faction_symbol(faction="", faction_raw="") -> str:
-    """ Returns faction-specific emote based on user_data faction strings or role strings """
+def get_faction_symbol(faction_role="", lifestate="") -> str:
+    """ Returns faction-specific emote based on faction role strings or user_data lifestates """
     result = None
 
-    if faction == ewcfg.role_kingpin:
-        if faction_raw == ewcfg.faction_rowdys:
+    # Special lifestate symbols
+    if lifestate == ewcfg.life_state_kingpin:
+        if lifestate == ewcfg.faction_rowdys:
             result = ewcfg.emote_rowdyfucker
-        elif faction_raw == ewcfg.faction_killers:
+        elif lifestate == ewcfg.faction_killers:
             result = ewcfg.emote_copkiller
+    elif lifestate == ewcfg.life_state_corpse:
+        result = ewcfg.emote_ghost
+    elif lifestate == ewcfg.life_state_juvenile:
+        result = ewcfg.emote_slime3
 
     if result is None:
-        if faction == ewcfg.role_corpse:
-            result = ewcfg.emote_ghost
-        elif faction == ewcfg.role_juvenile:
-            result = ewcfg.emote_slime3
-        elif faction == ewcfg.role_copkillers:
+        if faction_role == ewcfg.role_copkillers:
             result = ewcfg.emote_ck
-        elif faction == ewcfg.role_rowdyfuckers:
+        elif faction_role == ewcfg.role_rowdyfuckers:
             result = ewcfg.emote_rf
-        elif faction == ewcfg.role_slimecorp:
+        elif faction_role == ewcfg.role_slimecorp:
             result = ewcfg.emote_slimecorp
         else:
             result = ewcfg.emote_blank

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -397,7 +397,7 @@ def get_faction(user_data=None, life_state=0, faction="") -> str:
             faction_role = ewcfg.role_juvenile
 
     elif life_state == ewcfg.life_state_kingpin:
-        faction_role = ewcfg.role_kingpin
+
         if faction == ewcfg.faction_killers:
             faction_role = ewcfg.role_copkiller
         elif faction == ewcfg.faction_rowdys:

--- a/ew/utils/leaderboard.py
+++ b/ew/utils/leaderboard.py
@@ -706,7 +706,7 @@ def board_entry(entry, entry_type, divide_by):
 
     if entry_type == ewcfg.entry_type_player:
         faction = ewutils.get_faction(life_state=entry[1], faction=entry[2])
-        faction_symbol = ewutils.get_faction_symbol(faction, entry[2])
+        faction_symbol = ewutils.get_faction_symbol(faction_role=faction, lifestate=[1])
         number = int(entry[3] / divide_by)
 
         if number > 999999999:
@@ -723,7 +723,7 @@ def board_entry(entry, entry_type, divide_by):
     elif entry_type == ewcfg.entry_type_districts:
         faction = entry[0]
         districts = entry[1]
-        faction_symbol = ewutils.get_faction_symbol(faction.lower())
+        faction_symbol = ewutils.get_faction_symbol(faction_role=faction.lower())
 
         result = "\n{} `{:_>15} | {}`".format(
             faction_symbol,

--- a/ew/utils/leaderboard.py
+++ b/ew/utils/leaderboard.py
@@ -706,7 +706,7 @@ def board_entry(entry, entry_type, divide_by):
 
     if entry_type == ewcfg.entry_type_player:
         faction = ewutils.get_faction(life_state=entry[1], faction=entry[2])
-        faction_symbol = ewutils.get_faction_symbol(faction_role=faction, lifestate=[1])
+        faction_symbol = ewutils.get_faction_symbol(faction_role=faction, lifestate=entry[1])
         number = int(entry[3] / divide_by)
 
         if number > 999999999:

--- a/ew/utils/rolemgr.py
+++ b/ew/utils/rolemgr.py
@@ -61,6 +61,14 @@ async def updateRoles(client, member, server_default=None, refresh_perms=True, n
         user_data.life_state = ewcfg.life_state_grandfoe
         user_data.persist()
 
+    elif user_data.life_state == ewcfg.life_state_kingpin and ewcfg.role_kingpin not in roles_map_user:
+        # Fix the life_state for low-life gangstars
+        if user_data.faction:
+            user_data.life_state = ewcfg.life_state_enlisted
+        else:
+            user_data.life_state = ewcfg.life_state_juvenile
+        user_data.persist()
+
     # Manage faction roles.
     faction_role = ewutils.get_faction(user_data=user_data)
 


### PR DESCRIPTION
I fixed the dumb issue thing THAT WASNT MY FAULT! Turns out the cop killer and rowdy fucker roles are stored in the faction_roles list but weren't in the code that determined a user's proper faction roles, so it'd remove them and only add back the flat "kingpin" role, not the proper faction-specific ones.

**NOW**:
- Kingpin lifestates are tied to the "Kingpin" role. If you give it to a lowly gangster or juvie, they'll digivolve into their respective faction's kingpin based on their faction.
- If you remove the "Kingpin" role from a kingpin, they will degrade into a gangster if they have a faction, and a juvenile if they don't.
- Kingpin roles are fixed, and should not degrade
- Do NOT give the kingpin role to someone OR the rowdy fucker / cop killer role. DO NOT DO THAT.