### PR TITLE
Reimplemented Backfiring

### DIFF
--- a/client.py
+++ b/client.py
@@ -220,6 +220,7 @@ async def on_ready():
 
     for id_poi in poi_static.landmark_pois:
         ewutils.logMsg("beginning landmark precomputation for " + id_poi)
+        # Set each landmark's value to a dictionary of all pois, and their total cost from that landmark
         move_utils.landmarks[id_poi] = move_utils.score_map_from(
             poi_start=id_poi,
             user_data=fake_observer,

--- a/ew/backend/status.py
+++ b/ew/backend/status.py
@@ -268,7 +268,10 @@ def applyStatus(user_data, id_status = None, value = 0, source = "", multiplier 
             status_effect = EwStatusEffect(id_status=id_status, user_data=user_data, time_expire=time_expire, value=value, source=source, id_target=id_target)
 
             if id_status in statuses:
-                status_effect.value = value
+                if id_status == ewcfg.status_burning_id:
+                    status_effect.value = int(status_effect.value) + int(value)
+                else:
+                    status_effect.value = value
 
                 if status.time_expire > 0 and id_status in ewcfg.stackable_status_effects:
                     status_effect.time_expire += time_expire

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -605,7 +605,8 @@ async def item_look(cmd):
                     if captcha not in [None, ""]:
                         response += "Security Code: **{}**".format(ewutils.text_to_regional_indicator(captcha)) + "\n"
 
-                totalkills = int(item.item_props.get("totalkills")) if item.item_props.get("totalkills") != None else 0
+                totalkills = int(item.item_props.get("totalkills", 0))
+                totalsuicides = int(item.item_props.get("totalsuicides", 0))
 
                 if totalkills < 10:
                     response += "It looks brand new" + (
@@ -616,8 +617,10 @@ async def item_look(cmd):
                 else:
                     response += "A true legend in the battlefield, it has killed {} people.\n".format(totalkills)
 
-                response += "You have killed {} people with it.".format(
-                    item.item_props.get("kills") if item.item_props.get("kills") != None else 0)
+                if totalsuicides > 0:
+                    response += "Through sheer idiocy, it has killed {} of its own users.\n".format(totalsuicides)
+
+                response += "You have killed {} people with it.".format(item.item_props.get("kills", 0))
 
             if item.item_type == ewcfg.it_cosmetic:
                 response += "\n\n"

--- a/ew/cmd/item/itemutils.py
+++ b/ew/cmd/item/itemutils.py
@@ -138,14 +138,13 @@ def get_weapon_collection(id_item, id_server):
 
     for wep in weapon_inv:
         weapon_item = EwItem(id_item=wep.get('id_item'))
-        kills = weapon_item.item_props.get('totalkills')
-        if kills is None:
-            kills = 0
+        kills = weapon_item.item_props.get('totalkills', 0)
+        backfires = weapon_item.item_props.get('totalsuicides', 0)
         name = weapon_item.item_props.get('weapon_name')
         if name is None or name == '':
             name = 'Generic {}'.format(weapon_item.item_props.get('weapon_type'))
 
-        response += "{}: {} KILLS\n".format(name, kills)
+        response += "{}: {} KILLS{}\n".format(name, kills, ", {} BACKFIRES".format(backfires) if backfires > 0 else "")
 
     return response
 

--- a/ew/cmd/move/movecmds.py
+++ b/ew/cmd/move/movecmds.py
@@ -52,7 +52,7 @@ from .moveutils import send_arrival_response
 """
 
 
-async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
+async def move(cmd = None, isApt = False, continuousMove = -1):
     player_data = EwPlayer(id_user=cmd.message.author.id)
     user_data = EwUser(id_user=cmd.message.author.id, id_server=player_data.id_server, data_level=1)
     poi_current = poi_static.id_to_poi.get(user_data.poi)
@@ -64,21 +64,23 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
 
     if isApt == False and isDM == False and ewutils.channel_name_is_poi(cmd.message.channel.name) == False:
         channelid = fe_utils.get_channel(cmd.guild, poi_current.channel)
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "You must {} in a zone's channel.\n{}".format(
-                                                                                                       cmd.tokens[0],
-                                                                                                       "<#{}>".format(
-                                                                                                           channelid.id))))
+        return await fe_utils.send_message(
+            cmd.client,
+            cmd.message.channel,
+            fe_utils.formatMessage(cmd.message.author, "You must {} in a zone's channel.\n{}".format(cmd.tokens[0], "<#{}>".format(channelid.id)))
+        )
 
     target_name = ewutils.flattenTokenListToString(cmd.tokens[1:])
 
     if target_name == None or len(target_name) == 0:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, "Where to?"))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "Where to?"))
 
     if target_name in poi_static.streets:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "https://www.goodreads.com/quotes/106313-the-beginning-of-wisdom-is-to-call-things-by-their ...bitch"))
+        return await fe_utils.send_message(
+            cmd.client,
+            cmd.message.channel,
+            fe_utils.formatMessage(cmd.message.author, "https://www.goodreads.com/quotes/106313-the-beginning-of-wisdom-is-to-call-things-by-their ...bitch")
+        )
 
     poi = poi_static.id_to_poi.get(target_name)
     if poi_current.is_apartment == True:
@@ -103,22 +105,18 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
     if user_data.get_inhabitee():
         # prevent ghosts currently inhabiting other players from moving on their own
         response = "You might want to **{}** of the poor soul you've been tormenting first.".format(ewcfg.cmd_letgo)
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, response))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
     if ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(
             user_data.id_user) > 0:
         response = "You can't do that right now."
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, response))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
     if poi == None:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, "Never heard of it."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "Never heard of it."))
 
     if not ewutils.DEBUG  and isDM == False and not isApt and poi_static.chname_to_poi.get(cmd.message.channel.name).id_poi != user_data.poi:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You must {} in your current district.").format(
-            cmd.tokens[0]))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You must {} in your current district.").format(cmd.tokens[0]))
 
     if user_data.poi == ewcfg.debugroom:
         movement_method = "descending"
@@ -132,12 +130,13 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
 
     if user_data.poi == ewcfg.debugroom and cmd.tokens[0] != (
             ewcfg.cmd_descend) and poi.id_poi != ewcfg.poi_id_slimeoidlab:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "You can't move forwards or backwards in an {}, bitch.".format(
-                                                                                                       ewcfg.debugroom_short)))
+        return await fe_utils.send_message(
+            cmd.client,
+            cmd.message.channel,
+            fe_utils.formatMessage(cmd.message.author, "You can't move forwards or backwards in an {}, bitch.".format(ewcfg.debugroom_short))
+        )
     elif user_data.poi != ewcfg.debugroom and cmd.tokens[0] == (ewcfg.cmd_descend):
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "You can't move downwards on a solid surface, bitch."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You can't move downwards on a solid surface, bitch."))
 
     # if fetch_poi_if_coordless(poi.channel) is not None: # Triggers if your destination is a sub-zone.
     # 	poi = fetch_poi_if_coordless(poi.channel)
@@ -147,18 +146,15 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
     # 		poi = mother_poi
 
     if poi.id_poi == user_data.poi:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, "You're already there, bitch."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You're already there, bitch."))
     elif isApt and poi.id_poi == user_data.poi[3:]:
         return await ewapt.aptcmds.depart(cmd=cmd)
 
     if move_utils.inaccessible(user_data=user_data, poi=poi):
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "You're not allowed to go there (bitch)."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You're not allowed to go there (bitch)."))
 
     if user_data.life_state == ewcfg.life_state_corpse and time.time() - user_data.time_lastdeath < ewcfg.time_to_manifest:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                   "You're not used to being dead yet, it takes a while to learn how to manifest your ghost and move around."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You're not used to being dead yet, it takes a while to learn how to manifest your ghost and move around."))
     if isApt:
         poi_current = poi_static.id_to_poi.get(user_data.poi[3:])
 
@@ -167,39 +163,17 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
         path = EwPath(cost=60)
     elif len(poi.neighbors.keys()) == 0 or poi_current == None or len(poi_current.neighbors.keys()) == 0:
         path = None
-    elif  poi_current.isSplit  != "" and poi.isSplit != "" and poi_current.isSplit != poi.isSplit and isSplit == False:#this code is probably my worst fucking code ever. we need to fix routing
-        cmd_swap = cmd.tokens
-        cmd.tokens = ['!goto', poi_current.isSplit]
-        await move(cmd=cmd, isSplit=1)
-        cmd.tokens = ['!goto', poi.isSplit]
-        await move(cmd=cmd, isSplit=2, continuousMove=ewutils.moves_active.get(cmd.message.author.id))
-        cmd.tokens = cmd_swap
-        return await move(cmd=cmd, isSplit=2, continuousMove=ewutils.moves_active.get(cmd.message.author.id))
-    elif poi.isSplit != "" and isSplit == False and poi_current.isSplit != poi.isSplit and poi.id_poi != poi.isSplit:
-        cmd_swap = cmd.tokens
-        cmd.tokens = ['!goto', poi.isSplit]
-        await move(cmd=cmd, isSplit=1)
-        cmd.tokens = cmd_swap
-        return await move(cmd=cmd, isSplit=2, continuousMove=ewutils.moves_active.get(cmd.message.author.id))
-    elif poi_current.isSplit != "" and isSplit == False and poi_current.isSplit != poi.isSplit and poi_current.id_poi != poi_current.isSplit:
-        cmd_swap = cmd.tokens
-        cmd.tokens = ['!goto', poi_current.isSplit]
-        await move(cmd=cmd, isSplit=1)
-        cmd.tokens = cmd_swap
-        return await move(cmd=cmd, isSplit=2, continuousMove=ewutils.moves_active.get(cmd.message.author.id))
     else:
         path = move_utils.path_to(
             poi_start=poi_current.id_poi,
             poi_end=target_name,
             user_data=user_data
         )
-
         if path != None:
             path.cost = int(path.cost / user_data.move_speed)
 
     if path == None:
-        return await fe_utils.send_message(cmd.client, cmd.message.channel,
-                                           fe_utils.formatMessage(cmd.message.author, "You don't know how to get there."))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You don't know how to get there."))
     if isApt or intoApt:
         path.cost += 20
     # global move_counter
@@ -243,9 +217,10 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
 
 
     if movement_method == "descending":
-        msg_walk_start = await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author,
-                                                                                                             "You press the button labeled {}. You will arrive in {} seconds.".format(
-                                                                                                                 poi.str_name, seconds)))
+        msg_walk_start = await fe_utils.send_message(
+            cmd.client,
+            cmd.message.channel,
+            fe_utils.formatMessage(cmd.message.author, "You press the button labeled {}. You will arrive in {} seconds.".format(poi.str_name, seconds)))
     else:
         distance_text = (" It's {} minute{}{} away.".format(
             minutes,
@@ -256,24 +231,19 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
 
         location = poi.str_name
 
-        if isSplit == 1:
-            aptText = ""
-            location = "your destination"
-            distance_text = ""
-
         if walking_into_sewers:
             if user_data.life_state == ewcfg.life_state_corpse:
-                walk_response = "You begin to sink through the earth, retreating to your corpse deep in {}.{}".format(
-                    poi.str_name, distance_text)
+                walk_response = "You begin to sink through the earth, retreating to your corpse deep in {}.{}".format(poi.str_name, distance_text)
             else:
                 walk_response = "You begin your descent to {}.{}\nI'm sure you've heard, but people who go down there don't come back alive. You still have time to **{}**, if you'd like.".format(
-                    location, distance_text, ewcfg.cmd_halt_alt1)
+                    location,
+                    distance_text,
+                    ewcfg.cmd_halt_alt1
+                )
         else:
             walk_response = "You begin {} to {}{}.{}".format(walk_text, location, aptText, distance_text)
 
-
-        if isSplit != 2:
-            msg_walk_start = await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, walk_response))
+        msg_walk_start = await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, walk_response))
 
         if isApt:
             await ewapt.aptcmds.depart(cmd=cmd, isGoto=True, movecurrent=move_current)
@@ -321,14 +291,13 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
                 break
 
         msg_walk_enter = await send_arrival_response(cmd, poi, channel)
-        if isSplit == 0:
-            try:
-                await msg_walk_start.delete()
-                await asyncio.sleep(30)
-                await msg_walk_enter.delete()
-                pass
-            except:
-                pass
+        try:
+            await msg_walk_start.delete()
+            await asyncio.sleep(30)
+            await msg_walk_enter.delete()
+            pass
+        except:
+            pass
 
     else:
         boost = 0
@@ -421,7 +390,7 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
                     poi_previous = poi_static.id_to_poi.get(user_data.poi)
                     # print('previous poi: {}'.format(poi_previous))
 
-                    await rutils.movement_checker(user_data, poi_previous, poi_current, cmd)
+                    rutils.movement_checker(user_data, poi_previous, poi_current, cmd)
 
                     user_data.poi = poi_current.id_poi
                     user_data.time_lastenter = int(time.time())
@@ -453,18 +422,17 @@ async def move(cmd = None, isApt = False, isSplit = 0, continuousMove = -1):
                             id_ad = random.choice(ads)
                             ad_data = EwAd(id_ad=id_ad)
                             ad_response = format_ad_response(ad_data)
-                            await fe_utils.send_message(cmd.client, channel,
-                                                        fe_utils.formatMessage(cmd.message.author, ad_response))
+                            await fe_utils.send_message(cmd.client, channel, fe_utils.formatMessage(cmd.message.author, ad_response))
 
         if intoApt and ewutils.moves_active[cmd.message.author.id] == move_current and move_current != 0:
             await ewapt.aptcmds.retire(cmd=cmd, isGoto=True, movecurrent=move_current)
-        if isSplit == 0:
-            await asyncio.sleep(30)
-            try:
-                await msg_walk_start.delete()
-                pass
-            except:
-                pass
+
+        await asyncio.sleep(30)
+        try:
+            await msg_walk_start.delete()
+            pass
+        except:
+            pass
 
 
 async def dm_move(cmd):

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -69,7 +69,7 @@ async def attack(cmd):
 
         # Setup flavortext variables
         # this is disgusting, who wrote this?
-        response, mass_status, wep_explode, napalm, hit_msg, rel_warn, new_cap, slimeoid_resp, bounty_resp, contract_resp, lvl_resp = "", None, None, "", "", "", "", "", "", "", ""
+        response, mass_status, wep_explode, napalm, hit_msg, bkf_msg, rel_warn, new_cap, slimeoid_resp, bounty_resp, contract_resp, lvl_resp = "", None, None, "", "", "", "", "", "", "", "", ""
         target_killed = False
         bounty = 0
 
@@ -488,9 +488,14 @@ async def attack(cmd):
 
         if ctn.backfire_damage > 0:
             # Flavor from backfires
-            backfire_msg = "\n\n" + attacker_weapon.str_backfire.format(
+            bkf_msg = "\n\n" + attacker_weapon.str_backfire.format(
                 name_player=attacker_member.display_name,
+                name_target=target_member.display_name
             )
+            if attacker_killed:
+                bkf_msg += "\nYou have been destroyed by your own stupidity."
+            else:
+                bkf_msg += "\nYou lose {} slime!\n".format(ctn.backfire_damage)
 
         """ Final Operations """
 
@@ -529,7 +534,7 @@ async def attack(cmd):
         if napalm != "": resp_ctn.add_channel_response(cmd.message.channel, napalm)
         if die_resp is not None: resp_ctn.add_response_container(die_resp)
         if bkf_resp is not None: resp_ctn.add_response_container(bkf_resp)
-        response = hit_msg + rel_warn + new_cap + slimeoid_resp + bounty_resp + contract_resp
+        response = hit_msg + bkf_msg + rel_warn + new_cap + slimeoid_resp + bounty_resp + contract_resp
         resp_ctn.add_channel_response(cmd.message.channel, response)
         if lvl_resp != "": resp_ctn.add_channel_response(cmd.message.channel, "\n" + lvl_resp)
 

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -153,69 +153,98 @@ async def attack(cmd):
                     factions=["", target.faction], district_data=district_data
                 )
 
-            """ Slime & Coin Distribution """
+        """ Slime & Coin Distribution """  # Still calc'd on miss because backfiring :D
 
-            # Setup variables for slime distribution
-            target_killed = ctn.slimes_damage > target.slimes - target.bleed_storage
-            sewer_data = EwDistrict(district=ewcfg.poi_id_thesewers, id_server=cmd.guild.id)
-            to_sewer, to_attacker, to_bleed, to_district, to_kingpin = 0, ctn.slimes_spent * -1, 0, 0, 0
+        # Setup variables for slime distribution
+        target_killed = ctn.slimes_damage > target.slimes - target.bleed_storage
+        to_sewer, to_attacker, to_bleed, to_district, to_kingpin = 0, ctn.slimes_spent * -1, 0, 0, 0
 
-            # Determine how slime will be distributed
-            if target_killed:
+        # Determine how slime will be distributed
+        if target_killed:
 
-                # attacker gets half slime and half is drained on teamkill, otherwise attacker gets all
-
-                if target.life_state == ewcfg.life_state_enlisted and target.faction == attacker.faction:
-                    to_sewer = target.slimes/2
-                    to_attacker += target.slimes/2
-                else:
-                    to_attacker += target.slimes
-
-                # Transfer bounty
-                bounty = int(target.bounty / ewcfg.slimecoin_exchangerate)
-                attacker.change_slimecoin(n=bounty, coinsource=ewcfg.coinsource_bounty)
+            # attacker gets half slime and half is drained on teamkill, otherwise attacker gets all
+            if target.life_state == ewcfg.life_state_enlisted and target.faction == attacker.faction:
+                to_sewer = target.slimes/2
+                to_attacker += target.slimes/2
             else:
-                if target.life_state in [ewcfg.life_state_juvenile]:
-                    # attacking juvies sends half to bleed and half to splatter
-                    to_bleed = ctn.slimes_damage/2
-                    to_district = ctn.slimes_damage/2
-                elif target.life_state == ewcfg.life_state_enlisted and target.faction == attacker.faction:
-                    # attacking enlisted teammates sends half to sewers, 1/4 to bleed, and 1/4 to splatter
-                    to_sewer = ctn.slimes_damage/2
-                    to_bleed = ctn.slimes_damage/4
-                    to_district = ctn.slimes_damage/4
-                else:
-                    # Attacking other combatants sends half to kingpin, 1/4 to bleed, and 1/4 to splatter
-                    to_kingpin = ctn.slimes_damage/2
+                to_attacker += target.slimes
 
-                    to_bleed = ctn.slimes_damage/4
-                    to_district = ctn.slimes_damage/4
+            # Transfer bounty
+            bounty = int(target.bounty / ewcfg.slimecoin_exchangerate)
+            attacker.change_slimecoin(n=bounty, coinsource=ewcfg.coinsource_bounty)
+        else:
+            if target.life_state in [ewcfg.life_state_juvenile]:
+                # attacking juvies sends half to bleed and half to splatter
+                to_bleed = ctn.slimes_damage/2
+                to_district = ctn.slimes_damage/2
+            elif target.life_state == ewcfg.life_state_enlisted and target.faction == attacker.faction:
+                # attacking enlisted teammates sends half to sewers, 1/4 to bleed, and 1/4 to splatter
+                to_sewer = ctn.slimes_damage/2
+                to_bleed = ctn.slimes_damage/4
+                to_district = ctn.slimes_damage/4
+            else:
+                # Attacking other combatants sends half to kingpin, 1/4 to bleed, and 1/4 to splatter
+                to_kingpin = ctn.slimes_damage/2
+                to_bleed = ctn.slimes_damage/4
+                to_district = ctn.slimes_damage/4
 
-            # nosferatu gives attacker 60% of splatter
-            if to_district > 0 and ewcfg.mutation_id_nosferatu in attacker_mutations and (20 <= market_data.clock or market_data.clock < 6):
-                to_attacker += to_district * 0.6
-                to_district *= 0.4
+        # nosferatu gives attacker 60% of splatter
+        if to_district > 0 and ewcfg.mutation_id_nosferatu in attacker_mutations and (20 <= market_data.clock or market_data.clock < 6):
+            to_attacker += to_district * 0.6
+            to_district *= 0.4
 
-            # Handyman gives kingpin twice as much slime when attacking with a tool
-            if to_kingpin > 0 and ewcfg.mutation_id_handyman in attacker_mutations and attacker_weapon.is_tool:
-                to_kingpin *= 2
+        # Have backfire effect considered with slime gained from the kill already theirs
+        attacker_killed = ctn.backfire_damage > attacker.slimes + to_attacker - attacker.bleed_storage
+        if attacker_killed:
+            # Distribution for enlisted gangsters attacking enlisted rival gangsters
+            if attacker.life_state == ewcfg.life_state_enlisted and attacker.faction != target.faction:
+                to_sewer += (attacker.slimes + to_attacker) / 2
+                to_kingpin += (attacker.slimes + to_attacker) / 2
+            # Distribution for Juvies
+            else:
+                to_sewer += attacker.slimes + to_attacker
 
-            # Actually distribute slime now
-            if attacker.faction not in [ewcfg.faction_slimecorp, target.faction] and attacker.life_state not in [ewcfg.life_state_juvenile]:
-                # Kingpin only gets slime if not a teamkill or shill, or juvie, or shambler attacking
-                kingpin = fe_utils.find_kingpin(id_server=cmd.guild.id, kingpin_role=ewcfg.role_rowdyfucker if attacker.faction == ewcfg.faction_rowdys else ewcfg.role_copkiller)
-                if kingpin:
-                    kingpin = EwUser(id_server=cmd.guild.id, id_user=kingpin.id_user)
-                    kingpin.change_slimes(n=int(to_kingpin))
-                    kingpin.persist() # THIS ONLY GETS PERSISTED HERE BECAUSE THIS IS THE ONLY PLACE IT WILL EVER BE USED
-            if not target_killed:
-                # only take away slime if they survived to care
-                target.change_slimes(n=-1 * (ctn.slimes_damage - to_bleed), source=ewcfg.source_damage)
-                target.bleed_storage += to_bleed
+            to_attacker = 0  # Don't give their ghost slime
+        else:
+            # Distribution for enlisted gangsters attacking enlisted rival gangsters
+            if attacker.life_state == ewcfg.life_state_enlisted and attacker.faction != target.faction:
+                to_district += ctn.backfire_damage / 2
+                to_kingpin += ctn.backfire_damage / 2
+            # Distribution for Juvie attackers and juvie/ally targets
+            else:
+                to_sewer += ctn.backfire_damage
+
+            to_attacker -= ctn.backfire_damage  # Why add another line to the actual distribution?
+
+        # Handyman gives kingpin twice as much slime when attacking with a tool
+        if to_kingpin > 0 and ewcfg.mutation_id_handyman in attacker_mutations and attacker_weapon.is_tool:
+            to_kingpin *= 2
+
+        # Actually distribute slime now
+        if attacker.faction not in [ewcfg.faction_slimecorp, target.faction] and attacker.life_state not in [ewcfg.life_state_juvenile] and to_kingpin > 0:
+            # Kingpin only gets slime if not a teamkill or shill, or juvie, or shambler attacking
+            kingpin = fe_utils.find_kingpin(id_server=cmd.guild.id, kingpin_role=ewcfg.role_rowdyfucker if attacker.faction == ewcfg.faction_rowdys else ewcfg.role_copkiller)
+            if kingpin:
+                kingpin = EwUser(id_server=cmd.guild.id, id_user=kingpin.id_user)
+                kingpin.change_slimes(n=int(to_kingpin))
+                kingpin.persist() # THIS ONLY GETS PERSISTED HERE BECAUSE THIS IS THE ONLY PLACE IT WILL EVER BE USED
+
+        if (not target_killed) and (ctn.slimes_damage != 0):
+            # only take away slime if they survived to care
+            target.change_slimes(n=-1 * (ctn.slimes_damage - to_bleed), source=ewcfg.source_damage)
+            target.bleed_storage += to_bleed
+
+        if (not attacker_killed) and (to_attacker != 0):
+            # Distribution is calculated assuming they only get/lose any slime if they survive
+            lvl_resp = attacker.change_slimes(n=int(to_attacker), source=ewcfg.source_killing if to_attacker >= 0 else ewcfg.source_self_damage)
+
+        if to_sewer > 0:
+            sewer_data = EwDistrict(district=ewcfg.poi_id_thesewers, id_server=cmd.guild.id)
             sewer_data.change_slimes(n=int(to_sewer))
-            sewer_data.persist() # this is the ONLY exception to "persist everything at the end" (aside from kingpin) because it is SOLELY used here
+            sewer_data.persist()  # this is the ONLY exception to "persist everything at the end" (aside from kingpin) because it is SOLELY used here
+
+        if to_district > 0:
             district_data.change_slimes(n=int(to_district), source=ewcfg.source_killing)
-            lvl_resp = attacker.change_slimes(n=int(to_attacker), source=ewcfg.source_killing)
 
         """ Misc. Value Changes & Stat Changes"""
 
@@ -226,6 +255,24 @@ async def attack(cmd):
         if ewcfg.weapon_class_captcha in attacker_weapon.classes:
             attacker_weapon_item.item_props["captcha"] = ewutils.generate_captcha(length=attacker_weapon.captcha_length, user_data=attacker)
         attacker.hunger += ewcfg.hunger_pershot * ewutils.hunger_cost_mod(attacker.slimelevel)
+
+        # Values changed on backfire
+        if ctn.backfire_damage > 0:
+            # Weapon Data Changes
+            attacker_weapon_item.item_props["consecutive_hits"] = 0  # we'll do this before the increment, to be nice
+
+            # User Data Changes
+            attacker.time_lasthit = int(start_time)
+
+            # If ya did an oopsie
+            if attacker_killed:
+                # Weapon Data Changes
+                attacker_weapon_item.item_props["totalsuicides"] = 1 + int(attacker_weapon_item.item_props.get("totalsuicides", 0))
+
+                # User Data Changes
+                attacker.trauma = ewcfg.trauma_id_backfire
+                attacker.id_killer = attacker.id_user
+                attacker.divide_weaponskill(fraction=math.inf, weapon_type=attacker_weapon.id_weapon)
 
         if ctn.miss:
             # Value Changes on misses
@@ -264,7 +311,6 @@ async def attack(cmd):
 
 
                 # Stat Updates
-                start = time.perf_counter()
                 debug16(attacker_weapon_item, attacker, target)
                 ewstats.increment_stat(user=attacker, metric=ewcfg.stat_kills)
                 ewstats.track_maximum(user=attacker, metric=ewcfg.stat_biggest_kill, value=target.totaldamage + target.slimes)
@@ -273,8 +319,8 @@ async def attack(cmd):
                     ewstats.increment_stat(user=attacker, metric=ewcfg.stat_lifetime_ganks)
                 elif attacker.slimelevel < target.slimelevel:
                     ewstats.increment_stat(user=attacker, metric=ewcfg.stat_lifetime_takedowns)
-
-                end = time.perf_counter()
+                if ewcfg.slimernalia_active and attacker.life_state == ewcfg.life_state_juvenile:
+                    ewstats.change_stat(id_server=attacker.id_server, id_user=attacker.id_user, metric=ewcfg.stat_festivity, n=ewcfg.festivity_kill_bonus)
 
             else:
                 attacker.change_crime(n=ewcfg.cr_assault_points)
@@ -307,7 +353,6 @@ async def attack(cmd):
         if ewcfg.weapon_class_captcha in attacker_weapon.classes:
             new_cap += "\nNew security code: **{}**".format(ewutils.text_to_regional_indicator(attacker_weapon_item.item_props.get("captcha")))
 
-        bonus1 = ""
         bonus1 = debug17(attacker_weapon_item)
 
         if target_killed:
@@ -321,9 +366,6 @@ async def attack(cmd):
                 bonus1 = bonus1
             ))
 
-            if ewcfg.slimernalia_active and attacker.life_state == ewcfg.life_state_juvenile:
-                ewstats.change_stat(id_server=attacker.id_server, id_user=attacker.id_user, metric=ewcfg.stat_festivity, n=ewcfg.festivity_kill_bonus)
-            
             if attacker_slimeoid.life_state == ewcfg.slimeoid_state_active:
                 slimeoid_resp += "\n\n" + sl_static.brain_map.get(attacker_slimeoid.ai).str_kill.format(slimeoid_name=attacker_slimeoid.name)
 
@@ -412,7 +454,6 @@ async def attack(cmd):
                     }
                 )
 
-
         elif not ctn.miss:
             # Flavor for non fatal blows only
             hit_msg = attacker_weapon.str_damage.format(
@@ -445,6 +486,12 @@ async def attack(cmd):
                 bonus1 = bonus1
             )
 
+        if ctn.backfire_damage > 0:
+            # Flavor from backfires
+            backfire_msg = "\n\n" + attacker_weapon.str_backfire.format(
+                name_player=attacker_member.display_name,
+            )
+
         """ Final Operations """
 
         # Fulfill possession if necessary
@@ -459,7 +506,8 @@ async def attack(cmd):
 
         # Now we're allowed to run explosions.
         die_resp = None
-        if target_killed:
+        bkf_resp = None
+        if target_killed and EwUser(member=target_member).life_state != ewcfg.life_state_corpse:
             # This MUST be run before weapon explosions, in case the weapon explosion triggers a spontaneous combustion
             # That case could kill the target, and running this afterward would kill the target twice, dropping items x2
             die_resp = await target.die(cause=ewcfg.cause_killing)
@@ -470,25 +518,31 @@ async def attack(cmd):
                                            life_states=[ewcfg.life_state_enlisted, ewcfg.life_state_juvenile, ewcfg.life_state_executive],
                                            factions=["", target.faction],
                                            slimes_damage=ctn.bystander_damage, time_now=start_time, target_enemy=False)
+        if (EwUser(member=attacker_member).life_state != ewcfg.life_state_corpse) and attacker_killed:
+            # Funny enough, this must be run AFTER the weapon explosion, as explosions can reward slime to the attacker,
+            # which we can't have happening for a ghost, and it needs the attacker's weapon. Chance of slimegain is too low for me to factor it into whether they die or not though
+            bkf_resp = await attacker.die(cause=ewcfg.cause_backfire)
 
         # build final response
         if mass_status is not None: resp_ctn.add_response_container(mass_status)
         if wep_explode is not None: resp_ctn.add_response_container(wep_explode)
         if napalm != "": resp_ctn.add_channel_response(cmd.message.channel, napalm)
         if die_resp is not None: resp_ctn.add_response_container(die_resp)
+        if bkf_resp is not None: resp_ctn.add_response_container(bkf_resp)
         response = hit_msg + rel_warn + new_cap + slimeoid_resp + bounty_resp + contract_resp
         resp_ctn.add_channel_response(cmd.message.channel, response)
         if lvl_resp != "": resp_ctn.add_channel_response(cmd.message.channel, "\n" + lvl_resp)
 
         # Now copy for the killfeed if necessary
-        if target_killed:
+        if target_killed or attacker_killed:
             kf_ctn = EwResponseContainer(id_server=cmd.guild.id)
             resps = resp_ctn.channel_responses.get(cmd.message.channel, []) + resp_ctn.channel_responses.get(cmd.message.channel.name, [])
             for msg in resps:
                 kf_ctn.add_channel_response(ewcfg.channel_killfeed, msg)
             kf_ctn.format_channel_response(ewcfg.channel_killfeed, attacker_member)
             kf_ctn.add_channel_response(ewcfg.channel_killfeed, "`-------------------------`")
-            resp_ctn.add_member_to_update(target_member)
+            if target_killed: resp_ctn.add_member_to_update(target_member)
+            if attacker_killed: resp_ctn.add_member_to_update(attacker_member)
 
     elif check_resp == ewcfg.ghost_busting_string:
         """

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -7,7 +7,7 @@ from ew.backend import hunting as bknd_hunt
 #from ew.backend.dungeons import EwGamestate
 from ew.backend.item import EwItem
 from ew.backend.market import EwMarket
-from ew.backend.player import EwPlayer
+from ew.backend.player import EwPlayer, player_update
 from ew.static import cfg as ewcfg
 from ew.static import poi as poi_static
 from ew.static import slimeoid as sl_static
@@ -110,11 +110,14 @@ def apply_status_bystanders(user_data = None, value = 0, life_states = None, fac
         bystander_users = district_data.get_players_in_district(life_states=life_states, factions=factions, pvp_only=True)
         resp_cont = EwResponseContainer(id_server=user_data.id_server)
         channel = poi_static.id_to_poi.get(district_data.name).channel
+        guild = ewutils.get_client().get_guild(user_data.id_server)
         market_data = EwMarket(id_server=user_data.id_server)
 
         for bystander in bystander_users:
             bystander_user_data = EwUser(id_user=bystander, id_server=user_data.id_server)
             bystander_player_data = EwPlayer(id_user=bystander, id_server=user_data.id_server)
+            if bystander_player_data.display_name in ["", None]:
+                player_update(guild.get_member(bystander), guild)
             bystander_mutation = bystander_user_data.get_mutations()
 
             if market_data.weather == ewcfg.weather_rainy and status == ewcfg.status_burning_id:
@@ -174,6 +177,8 @@ async def weapon_explosion(user_data = None, shootee_data = None, district_data 
 
                 target_data = EwUser(id_user=bystander, id_server=user_data.id_server, data_level=1)
                 target_player = EwPlayer(id_user=bystander, id_server=user_data.id_server)
+                if target_player.display_name in ["", None]:
+                    player_update(await server.fetch_member(bystander), server)
 
                 target_isjuvenile = target_data.life_state == ewcfg.life_state_juvenile
 

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -97,6 +97,7 @@ class EwEffectContainer:
         # Find a way at some point to pass these in on initialization if you NEEEEEED to
         self.apply_status = {}
         self.mass_apply_status = None
+        self.backfire_damage = 0
         self.vax = vax
 
 

--- a/ew/model/poi.py
+++ b/ew/model/poi.py
@@ -128,9 +128,6 @@ class EwPoi:
     # The wiki page associated with that poi
     wikipage = ""
 
-    #check to split POI
-    isSplit = ""
-
     #if !jump will take you anywhere
     jump_dest = ""
 
@@ -177,7 +174,6 @@ class EwPoi:
             neighbors = None,
             topic = "",
             wikipage = "",
-            isSplit = "",
             jump_dest = ""
     ):
         self.id_poi = id_poi
@@ -221,7 +217,6 @@ class EwPoi:
         self.write_manuscript = write_manuscript
         self.topic = topic
         self.wikipage = wikipage
-        self.isSplit = isSplit
         self.jump_dest = jump_dest
 
         self.neighbors = neighbors

--- a/ew/model/weapon.py
+++ b/ew/model/weapon.py
@@ -56,6 +56,9 @@ class EwWeapon:
     # Displayed when a weapon effect causes a miss.
     str_miss = ""
 
+    # Displayed when a weapon effect causes backfire damage
+    str_backfire = ""
+
     # Displayed when !inspect-ing
     str_description = ""
 
@@ -122,6 +125,7 @@ class EwWeapon:
             fn_effect = None,
             str_crit = "",
             str_miss = "",
+            str_backfire = "",
             str_description = "",
             str_reload = "",
             str_reload_warning = "",
@@ -158,6 +162,7 @@ class EwWeapon:
         self.fn_effect = fn_effect
         self.str_crit = str_crit
         self.str_miss = str_miss
+        self.str_backfire = str_backfire
         self.str_description = str_description
         self.str_reload = str_reload
         self.str_reload_warning = str_reload_warning

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -3481,6 +3481,7 @@ injury_weights = {
 }
 
 trauma_id_suicide = "suicide"
+trauma_id_backfire = "backfire"
 trauma_id_betrayal = "betrayal"
 trauma_id_environment = "environment"
 

--- a/ew/static/poi.py
+++ b/ew/static/poi.py
@@ -2866,7 +2866,6 @@ poi_list = [
         is_subzone=True,
         father_district="downtown",
         neighbors={'limecorp2f': 20},
-        isSplit='limecorp1f',
         jump_dest='downtown'
     ),
     EwPoi(
@@ -2880,7 +2879,6 @@ poi_list = [
         is_subzone=True,
         father_district="downtown",
         neighbors={'limecorp3f': 20, 'limecorp1f': 20},
-        isSplit='limecorp1f'
     ),
     EwPoi(
         id_poi="limecorp1f",
@@ -2894,7 +2892,6 @@ poi_list = [
         is_subzone=True,
         father_district="downtown",
         neighbors={'limecorp2f': 20, 'downtown': 20},
-        isSplit='limecorp1f'
     ),
     EwPoi(
         id_poi="thesummit",
@@ -2908,7 +2905,6 @@ poi_list = [
         is_outskirts=True,
         neighbors={'temple': 20, 'skilodges': 20},
         wikipage="https://rfck.miraheze.org/wiki/Maimridge#The_Summit",
-        isSplit='colloidsprings',
         jump_dest='northoutskirtsedge'
     ),
     EwPoi(
@@ -2923,7 +2919,6 @@ poi_list = [
         is_outskirts=True,
         neighbors={'thesummit': 20, 'colloidsprings': 20},
         wikipage="https://rfck.miraheze.org/wiki/Maimridge#Ski_Lodges",
-        isSplit='colloidsprings'
     ),
     EwPoi(
         id_poi="colloidsprings",
@@ -2937,7 +2932,6 @@ poi_list = [
         is_outskirts=True,
         neighbors={'maimridge': 20, 'skilodges': 20},
         wikipage="https://rfck.miraheze.org/wiki/Maimridge#Colloid_Springs",
-        isSplit=''
     ),
     EwPoi(
         id_poi="temple",
@@ -2950,7 +2944,6 @@ poi_list = [
         father_district="maimridge",
         is_outskirts=False,
         neighbors={'thesummit': 20},
-        isSplit='colloidsprings'
     ),
     EwPoi(
         id_poi="rpcity",

--- a/ew/static/status.py
+++ b/ew/static/status.py
@@ -331,6 +331,12 @@ trauma_list = [
         trauma_class=ewcfg.trauma_class_damage,
     ),
     EwTrauma(
+        id_trauma=ewcfg.trauma_id_backfire,
+        str_trauma_self="You are suffering from a chronic case of stupidity.",
+        str_trauma="They are suffering from a chronic case of stupidity.",
+        trauma_class=ewcfg.trauma_class_damage
+    ),
+    EwTrauma(
         id_trauma=ewcfg.trauma_id_betrayal,
         str_trauma_self="You look anxious around your teammates, wary of betrayal.",
         str_trauma="They look anxious around their teammates, wary of betrayal.",

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -22,6 +22,7 @@ DEBUG = False
 
 DEBUG_OPTIONS = {
     'no_race_cooldown': False,
+    'verbose_burn': False,
 }
 
 # Map of user IDs to their course ID.


### PR DESCRIPTION
 - Removed captcha from molotov, for a price :}
 - Burn should be much more consistent in damage dealt, relative to what was applied
 - fixed a bug where weapon explosions and AOE burn would only grab player objects from the database for names, causing the creation of a player table entry with no name or avatar logged, and adding the flavortext for a bystander being hit, but not including the name.
   - For weapon explosions, this was implemented with fetch_member, so if someone has the new player bug or is failing to cap for no apparent reason, throw a grenade at an enemy gangster (relative to the broken player and the thrower) in the same district. Probably won't work but who knows
 - Also included isSplit removal from my master branch

If I did this poorly, both movement and murder could be broken, but testing showed combat and movement still perfectly functional, so let's hope it stays that way on live, but when this is pushed to live, be prepared to make a quick reversion, just in case. 