### PR TITLE
Log Cleanup and Minor Bug Fixing

### DIFF
--- a/client.py
+++ b/client.py
@@ -160,7 +160,7 @@ async def on_member_remove(member):
             return
 
         user_data.trauma = ewcfg.trauma_id_suicide
-        await user_data.die(cause=ewcfg.cause_leftserver)
+        await user_data.die(updateRoles=False, cause=ewcfg.cause_leftserver)
 
         ewutils.logMsg('Player killed for leaving the server.')
     except Exception as e:

--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -416,7 +416,7 @@ def item_dropall(user_data):
         bknd_core.execute_sql_query(
             "UPDATE items SET id_user = %s WHERE id_user = %s AND id_server = %s AND soulbound = 0", (
                 user_data.poi,
-                user_data.id_user,
+                str(user_data.id_user),
                 user_data.id_server
             ))
 

--- a/ew/cmd/apt/aptcmds.py
+++ b/ew/cmd/apt/aptcmds.py
@@ -1476,8 +1476,8 @@ async def remove_item(cmd):
     item_search = ewutils.flattenTokenListToString(cmd.tokens[startparse:])
 
     aptmodel = EwApartment(id_user=recipient, id_server=playermodel.id_server)
-    key_1 = EwItem(id_item=aptmodel.key_1)
-    key_2 = EwItem(id_item=aptmodel.key_2)
+    key_1 = EwItem(id_item=aptmodel.key_1) if aptmodel.key_1 != 0 else EwItem(id_item=None)
+    key_2 = EwItem(id_item=aptmodel.key_2) if aptmodel.key_2 != 0 else EwItem(id_item=None)
 
     if key_1.id_owner != str(usermodel.id_user) and key_2.id_owner != str(usermodel.id_user) and usermodel.visiting != ewcfg.location_id_empty:
         response = "Burglary takes finesse. You are but a lowly gangster, who takes money the old fashioned way."

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -933,7 +933,6 @@ async def jump(cmd):
     elif ewcfg.mutation_id_stiltwalker in user_data.get_mutations():
         blimp_obj = EwTransport(id_server=user_data.id_server, poi = ewcfg.poi_id_blimp)
         # If the user is under the blimp, put them on the blimp.
-        print(blimp_obj.current_stop)
         if user_data.poi == blimp_obj.current_stop:
 
             jump_response = "STR-EEEEETCHHHH!!!!"

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -459,7 +459,6 @@ async def inventory_print(cmd):
                     soulbound_style=("**" if item.get('soulbound') else ""),
                     quantity=(" x{:,}".format(item.get("quantity")) if (item.get("quantity") > 1) else "")
                 )
-                print(item.get("id_weapon"))
 
                 # Print item type labels if sorting by type and showing a new type of items
                 if sort_by_type:

--- a/ew/cmd/move/movecmds.py
+++ b/ew/cmd/move/movecmds.py
@@ -544,7 +544,7 @@ async def look(cmd):
 
     # if it's a subzone, check who owns the actual district
     if poi.is_subzone:
-        controlled_poi = poi_static.id_to_poi.get(poi.mother_districts[0])
+        controlled_poi = poi_static.id_to_poi.get(poi.mother_districts[0] if len(poi.mother_districts) > 0 else poi.father_district)
         controlled_data = EwDistrict(district=controlled_poi.id_poi, id_server=user_data.id_server)
     else:
         controlled_data = district_data
@@ -634,7 +634,7 @@ async def survey(cmd):
 
     # if it's a subzone, check who owns the actual district
     if poi.is_subzone:
-        controlled_poi = poi_static.id_to_poi.get(poi.mother_districts[0])
+        controlled_poi = poi_static.id_to_poi.get(poi.mother_districts[0] if len(poi.mother_districts) > 0 else poi.father_district)
         controlled_data = EwDistrict(district=controlled_poi.id_poi, id_server=user_data.id_server)
     else:
         controlled_data = district_data

--- a/ew/cmd/mutation/mutationcmds.py
+++ b/ew/cmd/mutation/mutationcmds.py
@@ -458,7 +458,6 @@ async def fursuit(cmd):
     # gets days until full moon
     if ewcfg.mutation_id_organicfursuit in mutations:
         days_until = -market_data.day % 29
-        print(days_until)
         if days_until > 15:
             days_until -= 16
         elif days_until <= 14:

--- a/ew/cmd/slimeoid/slimeoid_creation.py
+++ b/ew/cmd/slimeoid/slimeoid_creation.py
@@ -314,7 +314,7 @@ async def change_body_part(cmd):
         }
 
         # Gets part_map based on command used
-        desired_change, part_map = cmd_to_change_type.get(cmd.tokens[0])
+        desired_change, part_map = cmd_to_change_type.get(cmd.tokens[0].lower())
 
         if cmd.tokens_count == 1:
             if slimeoidtype == "Slimeoid":
@@ -426,7 +426,7 @@ async def change_stat(cmd):
             ewcfg.cmd_lowergrit: "- grit",
             ewcfg.cmd_lowerchutzpah: "- chutzpah",
         }
-        desired_change = cmd_to_change_type.get(cmd.tokens[0])
+        desired_change = cmd_to_change_type.get(cmd.tokens[0].lower())
 
         moxie_mod = 0
         grit_mod = 0

--- a/ew/cmd/slimeoid/slimeoidutils.py
+++ b/ew/cmd/slimeoid/slimeoidutils.py
@@ -207,11 +207,8 @@ class EwSlimeoidCombatData:
         size = self.moxie + self.grit + self.chutzpah
 
         # If the slimeoid is bigger than size_limit feet. Comes before other matchups, so stats together should equal size. Stats are 1 at minimum in CombatData
-        if(not size_limit):
-            size_limit = 42069
-        else:
-            size_limit += 3
-        print(size_limit)
+        size_limit = (size_limit + 3) if size_limit else 42069
+
         if size > size_limit:
             oversize = size - size_limit
 
@@ -478,7 +475,6 @@ async def battle_slimeoids(id_s1, id_s2, challengee_name, challenger_name, chann
     client = ewutils.get_client()
 
     # Nerf level to 10 if it's above 11.
-    print(size_limit)
     if(size_limit):
         challengee_level = min(challengee_slimeoid.level, size_limit)
         challenger_level = min(challenger_slimeoid.level, size_limit)

--- a/ew/cmd/smelting/smeltingcmds.py
+++ b/ew/cmd/smelting/smeltingcmds.py
@@ -212,6 +212,8 @@ async def find_recipes_by_item(cmd):
         found_recipe = smelting.smelting_recipe_map.get(sought_item)
         if found_recipe != None:
             used_recipe = found_recipe.id_recipe
+        else:
+            used_recipe = sought_item
 
         makes_sought_item = []
         uses_sought_item = []
@@ -245,7 +247,7 @@ async def find_recipes_by_item(cmd):
                 response = "The item you look to smelt is unable to be done so by chance.\n"
 
             for item in makes_sought_item:
-                if (used_recipe is not None) and (item.id_recipe == "toughcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_tough
+                if (item.id_recipe == "toughcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_tough
                         or item.id_recipe == "smartcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_smart
                         or item.id_recipe == "beautifulcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_beautiful
                         or item.id_recipe == "cutecosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_cute

--- a/ew/cmd/smelting/smeltingcmds.py
+++ b/ew/cmd/smelting/smeltingcmds.py
@@ -245,7 +245,7 @@ async def find_recipes_by_item(cmd):
                 response = "The item you look to smelt is unable to be done so by chance.\n"
 
             for item in makes_sought_item:
-                if (item.id_recipe == "toughcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_tough
+                if (used_recipe is not None) and (item.id_recipe == "toughcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_tough
                         or item.id_recipe == "smartcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_smart
                         or item.id_recipe == "beautifulcosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_beautiful
                         or item.id_recipe == "cutecosmetic" and cosmetics.cosmetic_map[used_recipe].style != ewcfg.style_cute

--- a/ew/utils/apt.py
+++ b/ew/utils/apt.py
@@ -169,8 +169,8 @@ async def toss_squatters(user_id = None, server_id = None, keepKeys = False):
                 ))
 
             squatters = cursor.fetchall()
-            key_1 = EwItem(id_item=apt_info.key_1).id_owner
-            key_2 = EwItem(id_item=apt_info.key_2).id_owner
+            key_1 = EwItem(id_item=apt_info.key_1).id_owner if apt_info.key_1 != 0 else ""
+            key_2 = EwItem(id_item=apt_info.key_2).id_owner if apt_info.key_2 != 0 else ""
             for squatter in squatters:
                 sqt_data = EwUser(id_user=squatter[0], id_server=player_info.id_server)
                 if keepKeys and (sqt_data.id_user == key_1 or sqt_data.id_user == key_2):

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -1734,7 +1734,7 @@ class EwUser(EwUserBase):
 
         client: discord.Client = ewcfg.get_client()
         server: discord.Guild = client.get_guild(self.id_server)
-        member: discord.Member = server.get_member(self.id_user)
+        member: EwPlayer = EwPlayer(id_server=self.id_server, id_user=self.id_user)
 
         # Make The death report
         deathreport = fe_utils.create_death_report(cause=cause, user_data=self, deathmessage = deathmessage)
@@ -1885,16 +1885,16 @@ class EwUser(EwUserBase):
         # Run explosion after location/stat reset, to prevent looping onto self
         if cause not in ewcfg.explosion_block_list:
             if user_has_combustion:
-                explode_resp = "\n{} spontaneously combusts, horribly dying in a fiery explosion of slime and shrapnel!! Oh, the humanity!\n".format(server.get_member(self.id_user).display_name)
+                explode_resp = "\n{} spontaneously combusts, horribly dying in a fiery explosion of slime and shrapnel!! Oh, the humanity!\n".format(member.display_name)
                 resp_cont.add_channel_response(explode_poi_channel, explode_resp)
 
                 explosion = await explode(damage=explode_damage, district_data=explode_district)
                 resp_cont.add_response_container(explosion)
 
-        ewutils.logMsg(f'Server {server.name} ({server.id}): {member.name} ({self.id_user}) was killed by {self.id_killer} - cause was {cause}')
+        ewutils.logMsg(f'Server {server.name} ({server.id}): {member.display_name} ({self.id_user}) was killed by {self.id_killer} - cause was {cause}')
         # You can opt out of the heavy roles update
         if updateRoles:
-            await ewrolemgr.updateRoles(client, member)
+            await ewrolemgr.updateRoles(client, server.get_member(self.id_user))
 
         return resp_cont
 


### PR DESCRIPTION
Apartment functions should no longer initialize EwItem(id_item=0) when apartments have no keys. Not urgent, but the logs get cluttered by the failure to find an item with the matching id.

Also removed some "print()" statements left in after testing by other contributors.