### PR TITLE
Calling EwStock() should no longer freeze the bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ ew/debugrelics.py
 /json_revert
 ew/cmd/debug/__init__.py
 
+faction_graphic.py
+buildfactionmap.sh

--- a/ew/backend/market.py
+++ b/ew/backend/market.py
@@ -218,20 +218,21 @@ class EwStock:
         elif self.total_shares >= 9223372036854775807:
             self.total_shares = 9223372036854775807
 
-    def __init__(self, id_server = None, stock = None, timestamp = None):
+    def __init__(self, id_server = None, stock = None, timestamp = None, only_latest = True):
         if id_server is not None and stock is not None:
             self.id_server = id_server
             self.id_stock = stock
 
             # get stock data at specified timestamp
             if timestamp is not None:
-                data = bknd_core.execute_sql_query("SELECT {stock}, {market_rate}, {exchange_rate}, {boombust}, {total_shares}, {timestamp} FROM stocks WHERE id_server = %s AND {stock} = %s AND {timestamp} = %s".format(
+                data = bknd_core.execute_sql_query("SELECT {stock}, {market_rate}, {exchange_rate}, {boombust}, {total_shares}, {timestamp} FROM stocks WHERE id_server = %s AND {stock} = %s AND {timestamp} = %s{limit}".format(
                     stock=ewcfg.col_stock,
                     market_rate=ewcfg.col_market_rate,
                     exchange_rate=ewcfg.col_exchange_rate,
                     boombust=ewcfg.col_boombust,
                     total_shares=ewcfg.col_total_shares,
-                    timestamp=ewcfg.col_timestamp
+                    timestamp=ewcfg.col_timestamp,
+                    limit=" LIMIT 1" if only_latest else " LIMIT 2"
                 ), (
                     id_server,
                     stock,
@@ -240,13 +241,14 @@ class EwStock:
             # otherwise get most recent data
             else:
 
-                data = bknd_core.execute_sql_query("SELECT {stock}, {market_rate}, {exchange_rate}, {boombust}, {total_shares}, {timestamp} FROM stocks WHERE id_server = %s AND {stock} = %s ORDER BY {timestamp} DESC".format(
+                data = bknd_core.execute_sql_query("SELECT {stock}, {market_rate}, {exchange_rate}, {boombust}, {total_shares}, {timestamp} FROM stocks WHERE id_server = %s AND {stock} = %s ORDER BY {timestamp} DESC{limit}".format(
                     stock=ewcfg.col_stock,
                     market_rate=ewcfg.col_market_rate,
                     exchange_rate=ewcfg.col_exchange_rate,
                     boombust=ewcfg.col_boombust,
                     total_shares=ewcfg.col_total_shares,
                     timestamp=ewcfg.col_timestamp,
+                    limit=" LIMIT 1" if only_latest else " LIMIT 2"
                 ), (
                     id_server,
                     stock

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -500,7 +500,8 @@ async def attack(cmd):
             # Flavor from backfires
             bkf_msg = "\n\n" + attacker_weapon.str_backfire.format(
                 name_player=attacker_member.display_name,
-                name_target=target_member.display_name
+                name_target=target_member.display_name,
+                hitzone=randombodypart,
             )
             if attacker_killed:
                 bkf_msg += "\nYou have been destroyed by your own stupidity."

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -603,6 +603,7 @@ async def attackEnemy(cmd):
     slimeoid = EwSlimeoid(member=cmd.message.author)
     market_data = EwMarket(id_server=cmd.guild.id)
     time_now_float = time.time()
+    levelup_response = ""
 
     time_now = int(time_now_float)
     # Get shooting player's info
@@ -720,7 +721,7 @@ async def attackEnemy(cmd):
         weapon_item.persist()
 
         # Spend slimes, to a minimum of zero
-        user_data.change_slimes(n=(-user_data.slimes if slimes_spent >= user_data.slimes else -slimes_spent), source=ewcfg.source_spending)
+        levelup_response += user_data.change_slimes(n=(-user_data.slimes if slimes_spent >= user_data.slimes else -slimes_spent), source=ewcfg.source_spending)
 
         user_data.limit_fix()
         user_data.persist()
@@ -832,11 +833,11 @@ async def attackEnemy(cmd):
         slimes_splatter = 0
 
     if ewcfg.mutation_id_nosferatu in user_mutations and (market_data.clock < 6 or market_data.clock >= 20):
-        user_data.change_slimes(n=slimes_splatter * 0.6, source=ewcfg.source_killing)
+        levelup_response += user_data.change_slimes(n=slimes_splatter * 0.6, source=ewcfg.source_killing)
         slimes_splatter *= .4
     
     if ewcfg.mutation_id_slurpsup in user_mutations or ewcfg.mutation_id_airlock in user_mutations and market_data.weather == ewcfg.weather_rainy:
-        user_data.change_slimes(n=slimes_splatter * 0.5, source=ewcfg.source_killing)
+        levelup_response += user_data.change_slimes(n=slimes_splatter * 0.5, source=ewcfg.source_killing)
         slimes_splatter *= 0.5
 
     district_data.change_slimes(n=slimes_splatter, source=ewcfg.source_killing)  # district gains 1/8 damage as slime
@@ -890,7 +891,7 @@ async def attackEnemy(cmd):
             slimes_tokiller = 0
 
         district_data.change_slimes(n=slimes_todistrict, source=ewcfg.source_killing)
-        levelup_response = user_data.change_slimes(n=slimes_tokiller, source=ewcfg.source_killing)
+        levelup_response += user_data.change_slimes(n=slimes_tokiller, source=ewcfg.source_killing)
         if ewcfg.mutation_id_fungalfeaster in user_mutations:
             user_data.hunger = 0
 

--- a/ew/utils/loop.py
+++ b/ew/utils/loop.py
@@ -1269,7 +1269,7 @@ async def clock_tick_loop(id_server = None, force_active = False):
                     ewutils.logMsg('The time is now {}.'.format(market_data.clock))
 
                     ewutils.logMsg("Updating stocks...")
-                    await market_utils.update_stocks(id_server)
+                    await market_utils.update_stocks(id_server=id_server, time_lasttick=time_now)
                     market_data.persist()
 
                     ewutils.logMsg("Handling weather cycle...")

--- a/ew/utils/market.py
+++ b/ew/utils/market.py
@@ -260,15 +260,15 @@ def get_majority_shareholder(id_server = None, stock = None):
 
 """ Update all the stocks currently available in the Stock Exchange """
 
-async def update_stocks(id_server = None):
-    if id_server:
+async def update_stocks(id_server = None, time_lasttick = None):
+    if id_server and time_lasttick:
         exchange_data = EwDistrict(district=ewcfg.poi_id_stockexchange, id_server=id_server)
         resp_cont = EwResponseContainer(ewcfg.get_client(), id_server=id_server)
         for stock in ewcfg.stocks:
             s = EwStock(id_server, stock)
             # we don't update stocks when they were just added
             if s.timestamp != 0:
-                s.timestamp = int(time.time())
+                s.timestamp = int(time_lasttick)
                 market_response = await stock_market_tick(s, id_server)
                 resp_cont.add_channel_response(ewcfg.channel_stockexchange, market_response)
                 resp_cont.add_channel_response(ewcfg.channel_stockexchange_p, market_response)

--- a/ew/utils/market.py
+++ b/ew/utils/market.py
@@ -36,7 +36,7 @@ except:
 
 async def stock_market_tick(stock_data, id_server):
     market_data = EwMarket(id_server=id_server)
-    company_data = EwCompany(id_server=id_server, stock=stock_data.id_stock)
+    company_data = EwCompany(id_server=id_server, stock=stock_data.id_stock, only_latest=False)
     crashstate = EwGamestate(id_server=id_server, id_state='stockcrashdive').bit
 
     # Nudge the value back to stability.


### PR DESCRIPTION
 - Made all stock updates within a tick have the same timestamp, using same variable as the market's time_lasttick
 - Seeing as EwStock only every needs the latest, or 2 latest, entries for a stock, implemented a default limit of 1 with a switch to set the limit to 2

!menu was blocking heartbeats because it had to query for every. single. row. of every. single. stock. when used in the food court, even though all but the latest would be tossed out by the end of EwStock.__init__(). That was legitimately stupid. The query now includes the LIMIT sql keyword