### PR TITLE
bug fixes to snag and cliff stuff

### DIFF
--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -1003,9 +1003,9 @@ def inventory(
     return items
 
 
-"""
-    Assign an existing item to a player
-"""
+
+    #Assign an existing item to a player
+
 
 
 def give_item(

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -1134,7 +1134,15 @@ async def push(cmd):
                     item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)
 
             elif item_object.item_props.get('adorned'):
-                bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
+                if "slimeoid" in item_object.item_props and item_object.item_props.get("slimeoid"):
+                    pass
+                else:
+                    if "adorned" in item_object.item_props:
+                        item_object.item_props["adorned"] = "false"
+                    
+
+                    item_object.persist()
+                    bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
 
             else:
                 item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)


### PR DESCRIPTION
fix #1: my preventing spam snag/stow code was bad. It now accounts for named weapons being mixed into a multisnag and is hopefully generally more hardy. I added a try: except: so that if in the future an error gets thrown for whatever new reasons, the chests dont also become inaccessible because of it.

When u get pushed off the cliffs, cosmetic item props werent fixed, so when cosmetics were reeled up they'd be automatically adorned because adorned=True. The same was true of stuff that had slimeoid=True, but i decided to make slimeoids not lose their cosmetics when the *player* jumps off the cliff rather than drop them and set that to false. Some slimeoids can fly and if they jumped anyway, they should probably die and turn to a heart (but thisd be such a killjoy 0_0) so i dont think it makes much sense.