### PR TITLE
Frog feeding

### DIFF
--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -1,4 +1,5 @@
 import time
+import traceback, sys
 
 from . import core as bknd_core
 from . import worldevent as bknd_event
@@ -1064,7 +1065,7 @@ def give_item(
 
 
 def give_item_multi(id_list = None, destination = None):
-    if id_list != None and destination != None:
+    if id_list is not None and destination is not None:
         for id_item in id_list:
             remove_from_trades(id_item)
 
@@ -1081,12 +1082,13 @@ def give_item_multi(id_list = None, destination = None):
                     [destination]
                 ))
 
-        except:
-            ewutils.logMsg('Failed to mass move items.')
+        except Exception as e:
+            ewutils.logMsg('Failed to mass move items with Exception: {}'.format(e))
+            traceback.print_exc(file=sys.stdout)
 
         item_cache = bknd_core.get_cache(obj_type="EwItem")
-        for id in id_list:
-            cache_item = item_cache.get_entry(unique_vals={"id_item": id})
+        for ids in id_list:
+            cache_item = item_cache.get_entry(unique_vals={"id_item": ids})
             cache_item.update({'id_owner': destination})
             item_cache.set_entry(data=cache_item)
 

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -1831,7 +1831,7 @@ async def commands(cmd):
         response += "Commands:\n" + ewcfg.basic_commands
 
     elif ewutils.flattenTokenListToString(tokens=cmd.tokens[1]) == 'location':
-        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2]) if cmd.tokens_count >= 3 else ""
+        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2:]) if cmd.tokens_count >= 3 else ""
         poi_sought = poi_static.id_to_poi.get(poi_look, None)
         if poi_sought:
             command_output = location_commands(cmd=cmd, search_poi=poi_sought.id_poi)

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -1831,7 +1831,7 @@ async def commands(cmd):
         response += "Commands:\n" + ewcfg.basic_commands
 
     elif ewutils.flattenTokenListToString(tokens=cmd.tokens[1]) == 'location':
-        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2:]) if cmd.tokens_count >= 3 else ""
+        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2:]) if cmd.tokens_count >= 3 else user_data.poi
         poi_sought = poi_static.id_to_poi.get(poi_look, None)
         if poi_sought:
             command_output = location_commands(cmd=cmd, search_poi=poi_sought.id_poi)

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -1830,9 +1830,9 @@ async def commands(cmd):
     if "basic" in category:
         response += "Commands:\n" + ewcfg.basic_commands
 
-    elif ewutils.flattenTokenListToString(tokens=cmd.tokens[1]) == 'location':    
-        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2])
-        poi_sought = poi_static.id_to_poi.get(poi_look)
+    elif ewutils.flattenTokenListToString(tokens=cmd.tokens[1]) == 'location':
+        poi_look = ewutils.flattenTokenListToString(tokens=cmd.tokens[2]) if cmd.tokens_count >= 3 else ""
+        poi_sought = poi_static.id_to_poi.get(poi_look, None)
         if poi_sought:
             command_output = location_commands(cmd=cmd, search_poi=poi_sought.id_poi)
             if command_output != "":

--- a/ew/cmd/cmds/cmdsutils.py
+++ b/ew/cmd/cmds/cmdsutils.py
@@ -101,7 +101,7 @@ async def exec_mutations(cmd):
 
 def location_commands(cmd, search_poi = None):
     user_data = EwUser(member=cmd.message.author)
-    response = "**CURRENT LOCATION**:"
+    response = init_resp = "**CURRENT LOCATION**:"
 
     # Get either location searched or user location
     if search_poi is not None:
@@ -110,37 +110,40 @@ def location_commands(cmd, search_poi = None):
         poi = user_data.poi
     poi_obj = poi_static.id_to_poi.get(poi)
 
-    # Unique-ish commands first
-    if poi in [ewcfg.poi_id_nlacu, ewcfg.poi_id_neomilwaukeestate]:
-        response += "\n" + ewcfg.universities_commands
-    if ewcfg.district_unique_commands.get(poi) is not None:
-        response += "\n" + ewcfg.district_unique_commands.get(poi)
+    if poi_obj is not None:
+        response = init_resp = "**{}**".format(poi_obj.str_name)
 
-    # Generic commands second
-    if poi in [ewcfg.poi_id_mine, ewcfg.poi_id_mine_sweeper, ewcfg.poi_id_mine_bubble, ewcfg.poi_id_tt_mines,
-               ewcfg.poi_id_tt_mines_sweeper, ewcfg.poi_id_tt_mines_bubble, ewcfg.poi_id_cv_mines,
-               ewcfg.poi_id_cv_mines_sweeper, ewcfg.poi_id_cv_mines_bubble]:
-        response += "\n" + ewcfg.mine_commands
-    elif poi_obj.is_pier == True:
-        response += "\n" + ewcfg.pier_commands
-    elif poi_obj.is_transport_stop == True or poi_obj.is_transport == True:
-        response += "\n" + ewcfg.transport_commands
-    elif poi_obj.is_apartment:
-        response += "\n" + ewcfg.apartment_commands
-    elif poi in [ewcfg.poi_id_greencakecafe, ewcfg.poi_id_nlacu, ewcfg.poi_id_neomilwaukeestate,
-               ewcfg.poi_id_glocksburycomics]:
-        response += "\n" + ewcfg.zine_writing_places_commands
-    elif poi in [ewcfg.poi_id_ab_farms, ewcfg.poi_id_og_farms, ewcfg.poi_id_jr_farms]:
-        response += "\n" + ewcfg.farm_commands
+        # Unique-ish commands first
+        if poi in [ewcfg.poi_id_nlacu, ewcfg.poi_id_neomilwaukeestate]:
+            response += "\n" + ewcfg.universities_commands
+        if ewcfg.district_unique_commands.get(poi) is not None:
 
-    # Shops last
-    if len(poi_obj.vendors) != 0:
-        response += "\n" + ewcfg.shop_commands
+            response += "\n" + ewcfg.district_unique_commands.get(poi)
 
-    if response != "**CURRENT LOCATION**:":
-        return (response + "\n")
+        # Generic commands second
+        if poi in [ewcfg.poi_id_mine, ewcfg.poi_id_mine_sweeper, ewcfg.poi_id_mine_bubble, ewcfg.poi_id_tt_mines,
+                   ewcfg.poi_id_tt_mines_sweeper, ewcfg.poi_id_tt_mines_bubble, ewcfg.poi_id_cv_mines,
+                   ewcfg.poi_id_cv_mines_sweeper, ewcfg.poi_id_cv_mines_bubble]:
+            response += "\n" + ewcfg.mine_commands
+        elif poi_obj.is_pier:
+            response += "\n" + ewcfg.pier_commands
+        elif poi_obj.is_transport_stop or poi_obj.is_transport:
+            response += "\n" + ewcfg.transport_commands
+        elif poi_obj.is_apartment:
+            response += "\n" + ewcfg.apartment_commands
+        elif poi in [ewcfg.poi_id_greencakecafe, ewcfg.poi_id_nlacu, ewcfg.poi_id_neomilwaukeestate, ewcfg.poi_id_glocksburycomics]:
+            response += "\n" + ewcfg.zine_writing_places_commands
+        elif poi in [ewcfg.poi_id_ab_farms, ewcfg.poi_id_og_farms, ewcfg.poi_id_jr_farms]:
+            response += "\n" + ewcfg.farm_commands
+
+        # Shops last
+        if len(poi_obj.vendors) != 0:
+            response += "\n" + ewcfg.shop_commands
+
+    if response != init_resp:
+        return response + "\n"
     else:
-        return "No special commands for your current location. Try \"!commands basic\" or \"!help\"."
+        return "No special commands for {}. Try \"!commands basic\" or \"!help\".".format(poi_obj.str_name if poi_obj is not None else user_data.poi)
 
 
 def mutation_commands(cmd):

--- a/ew/cmd/fish/fishcmds.py
+++ b/ew/cmd/fish/fishcmds.py
@@ -688,7 +688,7 @@ async def barter(cmd):
 
             # Filters out items of greater value than your fish.
             for value_filter in items:
-                if value < value_filter.context:
+                if value < value_filter.price:
                     items.remove(value_filter)
                 else:
                     pass
@@ -1037,7 +1037,7 @@ async def barter_all(cmd):
                         pass
                 # Filters out items of greater value than your fish.
                 for value_filter in potential_items:
-                    if value < value_filter.context:
+                    if value < value_filter.price:
                         potential_items.remove(value_filter)
                     else:
                         pass

--- a/ew/cmd/juviecmd/juviecmdutils.py
+++ b/ew/cmd/juviecmd/juviecmdutils.py
@@ -734,9 +734,8 @@ def create_mining_event(cmd, toolused=None):
     uncommon_event_triggered = False
     rare_event_triggered = False
 
-    if user_data.weapon >= 0:
-        weapon_item = EwItem(id_item=user_data.weapon)
-        weapon = static_weapons.weapon_map.get(weapon_item.item_props.get("weapon_type"))
+    weapon_item = user_data.get_weapon_item()
+    weapon = static_weapons.weapon_map.get(weapon_item.item_props.get("weapon_type"))
 
     if randomn < rare_event_chance: # 5% chance, divided by # of players
         rare_event_triggered = True

--- a/ew/cmd/move/movecmds.py
+++ b/ew/cmd/move/movecmds.py
@@ -1166,7 +1166,7 @@ async def print_map_data(cmd):
         if poi.is_subzone:
             for neighbor in poi.neighbors.keys():
                 if neighbor not in poi.mother_districts:
-                    print('subzone {} has invalid mother district(s)'.format(poi.str_name))
+                    ewutils.logMsg('Subzone {} has invalid mother district(s)'.format(poi.str_name))
 
             # if neighbor_poi.id_poi in poi.neighbors.keys():
             # if poi.id_poi in neighbor_poi.neighbors.keys():

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -506,10 +506,10 @@ def canAttack(cmd):
             else:
                 response = "You lack the moral fiber necessary for violence."
 
-        elif move_utils.poi_is_pvp(user_data.poi) == False and enemy_data.enemytype not in [ewcfg.enemy_type_sandbag] and enemy_data.enemyclass != 'dojomaster':
+        elif (not move_utils.poi_is_pvp(user_data.poi)) and not (enemy_data is not None and (enemy_data.enemytype in [ewcfg.enemy_type_sandbag] or enemy_data.enemyclass == 'dojomaster')):
             response = "You must go elsewhere to commit gang violence."
 
-        elif enemy_data != None:
+        elif enemy_data is not None:
             if ewcfg.status_enemy_juviemode_id in enemy_data.getStatusEffects():
                 npc_obj = static_npc.active_npcs_map.get(enemy_data.enemyclass)
                 if npc_obj.str_juviemode != '' and npc_obj.str_juviemode is not None:

--- a/ew/static/items.py
+++ b/ew/static/items.py
@@ -472,7 +472,7 @@ item_list = [
         str_desc="OH GOD IT'S A FUCKING SEAWEED!",
         acquisition=ewcfg.acquisition_bartering,
         ingredients="generic",
-        context=10,
+        price=10,
     ),
     EwGeneralItem(
         id_item=ewcfg.item_id_oldboot,
@@ -480,7 +480,7 @@ item_list = [
         str_desc="OH GOD IT'S A FUCKING OLD BOOT!",
         acquisition=ewcfg.acquisition_bartering,
         ingredients="generic",
-        context=10,
+        price=10,
     ),
     EwGeneralItem(
         id_item=ewcfg.item_id_tincan,
@@ -488,7 +488,7 @@ item_list = [
         str_desc="OH GOD IT'S A FUCKING TIN CAN!",
         acquisition=ewcfg.acquisition_bartering,
         ingredients="generic",
-        context=10,
+        price=10,
     ),
     EwGeneralItem(
         id_item=ewcfg.item_id_oldcd,
@@ -496,7 +496,7 @@ item_list = [
         str_desc="OH GOD IT'S A FUCKING CD!",
         acquisition=ewcfg.acquisition_bartering,
         ingredients="generic", #figure out how to embed mixtapes into this
-        context=10,
+        price=10,
     ),
     EwGeneralItem(
         id_item=ewcfg.item_id_leather,
@@ -559,7 +559,7 @@ item_list = [
         str_desc="It’s just some string.",
         acquisition=ewcfg.acquisition_bartering,
         ingredients="generic",
-        context=60,
+        price=60,
     ),
     EwGeneralItem(
         id_item=ewcfg.item_id_spent_pod,

--- a/ew/static/weapons.py
+++ b/ew/static/weapons.py
@@ -112,10 +112,10 @@ def get_weapon_type_stats(weapon_type):
             "crit_chance": 0.1,
             "crit_multiplier": 1.5,
             "hit_chance": 0.8,
-            "backfire_chance": 1, # Guaranteed backfire with every attack
+            "backfire_chance": 1,  # Guaranteed backfire with every attack
             "backfire_multiplier": 0.15,
             "backfire_crit_mult": 0.75,  # Halve backfire damage relative to attack damage on crit
-            "backfire_miss_mult": 10, # Don't fuck it up or you're a dead motherfucker
+            "backfire_miss_mult": 10,  # Don't fuck it up or you're a dead motherfucker
         },
     }
 
@@ -247,7 +247,7 @@ def wef_garrote(ctn = None):
         ctn.slimes_damage *= 10
         ctn.crit = True
 
-    if ctn.miss == False:
+    if not ctn.miss:
         # Make damage integer
         ctn.slimes_damage = int(ctn.slimes_damage)
         # Stop movement
@@ -266,20 +266,21 @@ def wef_staff(ctn = None):
         lambda _: 3 <= market_data.clock < 4,  # witching hour
         lambda _: market_data.weather == ewcfg.weather_foggy,
         lambda _: ewutils.check_moon_phase(market_data) == ewcfg.moon_new,  # moonless night
-        lambda ctn: not ctn.user_data.has_soul,
-        lambda ctn: ctn.user_data.get_possession('weapon'),
-        lambda ctn: ctn.user_data.poi == ewcfg.poi_id_thevoid,
-        lambda ctn: ctn.shootee_data.slimes > ctn.user_data.slimes,
-        lambda ctn: (ctn.user_data.poi_death == ctn.user_data.poi) or (ctn.shootee_data.poi_death == ctn.shootee_data.poi),
-        lambda ctn: (ctn.user_data.id_killer == ctn.shootee_data.id_user) or (ctn.user_data.id_user == ctn.shootee_data.id_killer),
-        lambda ctn: (ctn.shootee_data.life_state == ewcfg.life_state_juvenile) or (ctn.shootee_data.life_state == ewcfg.life_state_enlisted and ctn.shootee_data.faction == ctn.user_data.faction),
-        lambda ctn: (ctn.shootee_data.gender == ctn.user_data.gender), # SGAB, or Same Gender Attack Bonus
+        lambda container: not container.user_data.has_soul,
+        lambda container: container.user_data.get_possession('weapon'),
+        lambda container: container.user_data.poi == ewcfg.poi_id_thevoid,
+        lambda container: container.shootee_data.slimes > container.user_data.slimes,
+        lambda container: (container.user_data.poi_death == container.user_data.poi) or (container.shootee_data.poi_death == container.shootee_data.poi),
+        lambda container: (container.user_data.id_killer == container.shootee_data.id_user) or (container.user_data.id_user == container.shootee_data.id_killer),
+        lambda container: (container.shootee_data.life_state == ewcfg.life_state_juvenile) or (container.shootee_data.life_state == ewcfg.life_state_enlisted and container.shootee_data.faction == container.user_data.faction),
+        lambda container: (container.shootee_data.gender == container.user_data.gender),  # SGAB, or Same Gender Attack Bonus
     }
     for condition in conditions:
         try:
             if condition(ctn):
                 conditions_met += 1
-        except:
+        except Exception as e:
+            ewutils.logMsg("Staff condition check for user {} failed.\nException: {}".format(ctn.user_data.id_user, e))
             pass
 
     ctn.slimes_spent = int(ctn.slimes_spent * 2)
@@ -790,7 +791,7 @@ weapon_list = [
             "bombs",
             "moly"
         ],
-        #str_backfire = "**Oh, the humanity!!** The bottle bursts in {name_player}'s hand, burning them terribly!!", Not needed with miss text included, double announcing basically
+        # str_backfire = "**Oh, the humanity!!** The bottle bursts in {name_player}'s hand, burning them terribly!!", Not needed with miss text included, double announcing basically
         str_miss="**OH FUCK!** Your molotov combusts and shatters all over you the moment {name_player} set it alight!",
         str_crit="{name_player}’s cocktail shatters at the feet of {name_target}, sending a shower of shattered shards of glass into them!!",
         str_equip="You equip the molotov cocktail.",
@@ -1126,7 +1127,7 @@ weapon_list = [
             'crit_spray': "**Critical hit!** The paint bullet skids a wall, spreading your paint across the whole thing!",
             'equip_spray': "You load a clip of paint into the gun and throw it onto your back, kinda like Rambo if he were an art major."
         },
-    str_brandish=["**SPLAAART!** {name} takes out {weapon} and inks the fuck out of a nearby splat zone!\n{tag}"]
+        str_brandish=["**SPLAAART!** {name} takes out {weapon} and inks the fuck out of a nearby splat zone!\n{tag}"]
     ),
     EwWeapon(  # 26
         id_weapon=ewcfg.weapon_id_paintroller,
@@ -1658,7 +1659,7 @@ weapon_list = [
         str_brandish=["{name} shakes {weapon}, but most people can't see it from this distance. It just looks like they're shaking their fist at them."]
     ),
     EwWeapon(  # 42 AWP
-        id_weapon=ewcfg.weapon_id_awp, #need to make
+        id_weapon=ewcfg.weapon_id_awp,  # need to make
         alias=[
             "l96",
             "sniperrifle",
@@ -1813,7 +1814,7 @@ weapon_list = [
         stat=ewcfg.stat_skateboard_kills,
         str_brandish=["Try !stunt."]
     ),
-EwWeapon(  # 48
+    EwWeapon(  # 48
         id_weapon=ewcfg.weapon_id_juvierang,
         alias=[
             "boomerang",
@@ -1826,7 +1827,7 @@ EwWeapon(  # 48
         str_weapon="a juvierang",
         str_weaponmaster_self="You are a rank {rank} {title} 'rang-er.",
         str_weaponmaster="They are a rank {rank} {title} 'rang-er.",
-        str_kill="**WHAP!** {name_target} is knocked to the ground by {name_player}'s juvierang. {name_player} picks it up and cleaves {name_player}'s throat to finish the kill. {emote_skull}",
+        str_kill=["**WHAP!** {name_target} is knocked to the ground by {name_player}'s juvierang. {name_player} picks it up and cleaves {name_player}'s throat to finish the kill. {emote_skull}"],
         str_killdescriptor="'rang'd",
         str_damage="{name_target} is knocked by a 'rang in the {hitzone}!!",
         str_duel="**WHIP! WHAP!!** {name_player} and {name_target} throw juvierangs at eachother like they're playing tower defense.",
@@ -2045,32 +2046,32 @@ slimeoid_weapon_type_convert = {
 }
 
 slimeoid_dmg_text = {
-    "blades":"slashed cleanly across the chest",
-    "teeth":"impaled by numerous sharp teeth",
-    "grip":"being deprived of oxygen",
-    "bludgeon":"struck hard in the skull",
-    "spikes":"skewered by a volley of jagged spikes",
-    "electricity":"tazed by a continuous arc of electricity",
-    "slam":"crushed under a massive weight"
+    "blades": "slashed cleanly across the chest",
+    "teeth": "impaled by numerous sharp teeth",
+    "grip": "being deprived of oxygen",
+    "bludgeon": "struck hard in the skull",
+    "spikes": "skewered by a volley of jagged spikes",
+    "electricity": "tazed by a continuous arc of electricity",
+    "slam": "crushed under a massive weight"
 }
 
 slimeoid_kill_text = {
-    "blades":"unleashes a flurry of strikes too fast for the eye to see. After a few heartbeats, slices slowly slide apart like fresh cut salami.",
-    "teeth":"clenches their prey in its powerful jaws. Ripping and tearing the head from its body until there’s nothing left but a stump.",
-    "grip":"has a tight stranglehold on their prey, squeezing until their brain bursts out of their skull like a cyst filled with grey matter.",
-    "bludgeon":"swiftly bashes their prey with force of a semi truck. Their bones are flung out of their body before vaporizing against a nearby building.",
-    "spikes":"slings a hail of gnarled spikes, pinning their victim against the wall like a carnival act. It eagerly picks off meat chunks of its prey to feast on like skewered BBQ.",
-    "electricity":"filled with unlimited power, charges up for a massive powerful arc, unleashing a blinding lightning strike. The taste of metal fills the static-charged atmosphere before its prey is struck with 80 jigawats of power.",
-    "slam":"jumps high into the air. With the force of an atomic warhead they crash down through the stratosphere and obliterate their prey below, painting the district green. "
+    "blades": "unleashes a flurry of strikes too fast for the eye to see. After a few heartbeats, slices slowly slide apart like fresh cut salami.",
+    "teeth": "clenches their prey in its powerful jaws. Ripping and tearing the head from its body until there’s nothing left but a stump.",
+    "grip": "has a tight stranglehold on their prey, squeezing until their brain bursts out of their skull like a cyst filled with grey matter.",
+    "bludgeon": "swiftly bashes their prey with force of a semi truck. Their bones are flung out of their body before vaporizing against a nearby building.",
+    "spikes": "slings a hail of gnarled spikes, pinning their victim against the wall like a carnival act. It eagerly picks off meat chunks of its prey to feast on like skewered BBQ.",
+    "electricity": "filled with unlimited power, charges up for a massive powerful arc, unleashing a blinding lightning strike. The taste of metal fills the static-charged atmosphere before its prey is struck with 80 jigawats of power.",
+    "slam": "jumps high into the air. With the force of an atomic warhead they crash down through the stratosphere and obliterate their prey below, painting the district green. "
 }
 
 
 slimeoid_crit_text = {
-"spit":"a rain of high velocity corrosive acid",
-"laser":"a searing white hot photon beam",
-"spines":"a hail of massive jagged spikes",
-"throw":"its unmatched strength and throws a car",
-"TK":"a brain blast of psychic waves",
-"fire":"a torrent of unrelenting dragon-like flames",
-"webs":"a high pressure string shot of sticky webs"
+    "spit": "a rain of high velocity corrosive acid",
+    "laser": "a searing white hot photon beam",
+    "spines": "a hail of massive jagged spikes",
+    "throw": "its unmatched strength and throws a car",
+    "TK": "a brain blast of psychic waves",
+    "fire": "a torrent of unrelenting dragon-like flames",
+    "webs": "a high pressure string shot of sticky webs"
 }

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -840,9 +840,9 @@ def total_size(o, verbose=False):
 
     return sizeof(o)
 
-#quick function to check presence in a district
-def is_district_empty(poi = ''):
-    data = bknd_core.execute_sql_query('SELECT {id_user} FROM USERS WHERE {poi} = %s LIMIT 1'.format(poi=ewcfg.col_poi, id_user=ewcfg.col_id_user), (poi,))
+
+def is_district_empty(poi = ''):  # quick function to check presence in a district
+    data = bknd_core.execute_sql_query('SELECT {id_user} FROM users WHERE {poi} = %s LIMIT 1'.format(poi=ewcfg.col_poi, id_user=ewcfg.col_id_user), (poi,))
     if len(data) > 0:
         return False
     else:

--- a/ew/utils/frontend.py
+++ b/ew/utils/frontend.py
@@ -775,14 +775,14 @@ async def prompt(cmd = None, target = None, question = "", wait_time = 30, accep
         try:
             message = await cmd.client.wait_for('message', timeout=30, check=lambda message: message.author == (target if checktarget else cmd.message.author) and message.content.lower() in [final_accept, final_decline])
 
-            if message != None:
+            if message is not None:
                 if message.content.lower() == final_accept:
                     accepted = True
                 if message.content.lower() == final_decline:
                     accepted = False
 
         except Exception as e:
-            print(e)
+            ewutils.logMsg("Frontend util prompt threw Exception: {}".format(e))
             accepted = False
     else:
         accepted = False

--- a/ew/utils/rolemgr.py
+++ b/ew/utils/rolemgr.py
@@ -224,19 +224,19 @@ async def remove_user_overwrites(cmd):
 
         channel = fe_utils.get_channel(server, searched_channel)
 
-        if channel == None:
+        if channel is None:
             # Second try
             channel = fe_utils.get_channel(server, searched_channel)
-            if channel == None:
+            if channel is None:
                 continue
 
         # print('{} overwrites: {}'.format(poi.id_poi, channel.overwrites))
-        for tuple in channel.overwrites:
+        for tuples in channel.overwrites:
             # print('tuplevar: {}'.format(tuple) + '\n\n')
-            if tuple not in server.roles:
-                member = tuple
+            if tuples not in server.roles:
+                member = tuples
 
-                print('removed overwrite in {} for {}'.format(channel, member))
+                ewutils.logMsg('Removed overwrite in {} for {}'.format(channel, member))
 
                 for i in range(ewcfg.permissions_tries):
                     await channel.set_permissions(member, overwrite=None)


### PR DESCRIPTION
 - create mining events without a weapon works now
 - !commands location will assume your current location when no 3rd token is given
 - !commands location may be used with whitespace in the poi target, without the need for quotations
 - !kill in a safezone without targeting an enemy no longer Errors
 - !brandish juvierangs response properly defined
 - !barter and !barterall changed to use item prices for value comparison, instead of context, to prevent int/str comparisons
 - Several instances of print() removed, or switched to logMsg and given context