### PR TITLE
Annoint and Status Mod Fixes

### DIFF
--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -66,7 +66,7 @@ try:
     from ew.static import rstatic as relic_static
 except:
     from ..debug_dummy import debug24
-    from ew.static import rstatic as relic_static
+    from ew.static import rstatic_dummy as relic_static
 
 """ show player's slime score """
 

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -1000,7 +1000,7 @@ async def annoint(cmd):
     # Make sure user has a weapon equipped before all else
     if user_data.weapon <= 0:
         response = "Equip a weapon first."
-        await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
     # Grab the wanted name
     if cmd.tokens_count < 2:

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -246,7 +246,7 @@ async def attack(cmd):
                 kingpin.change_slimes(n=int(to_kingpin))
                 kingpin.persist() # THIS ONLY GETS PERSISTED HERE BECAUSE THIS IS THE ONLY PLACE IT WILL EVER BE USED
 
-        if (not target_killed) and (ctn.slimes_damage != 0):
+        if (not target_killed) and (ctn.slimes_damage >= 0):
             # only take away slime if they survived to care
             target.change_slimes(n=-1 * (ctn.slimes_damage - to_bleed), source=ewcfg.source_damage)
             target.bleed_storage += to_bleed

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -1199,22 +1199,20 @@ def apply_attack_modifiers(ctn, hitzone, attacker_mutations, target_mutations, t
     )
 
     # Apply Damage Modifiers
-    ctn.slimes_damage *= (1 + round(attacker_status_mods['dmg'] + target_status_mods['dmg'], 2)) * \
-        misc_atk_mod * \
-        misc_def_mod
+    ctn.slimes_damage *= attacker_status_mods['dmg'] * target_status_mods['dmg'] * misc_atk_mod * misc_def_mod
 
     # apply hit chance modifiers
-    ctn.hit_chance_mod += round(attacker_status_mods['hit_chance'] + target_status_mods['hit_chance'], 2) - \
-                          (5-ctn.user_data.weaponskill)/10 if ctn.user_data.weaponskill < 5 else 0
+    ctn.hit_chance_mod += attacker_status_mods['hit_chance'] + target_status_mods['hit_chance'] - (5-ctn.user_data.weaponskill)/10 if ctn.user_data.weaponskill < 5 else 0
 
     # lucky lucky lucy, oh and also n4 lol
     if ctn.shootee_data.life_state == ewcfg.life_state_lucky or target_status_mods['untouchable']:
         ctn.miss = True
 
     # apply crit chance modifiers
-    ctn.crit_mod += round(attacker_status_mods['crit'] + target_status_mods['crit'], 2) + \
+    ctn.crit_mod += attacker_status_mods['crit'] + target_status_mods['crit'] + \
         0.1 if (ewcfg.mutation_id_airlock in attacker_mutations or ewcfg.mutation_id_foghorn in attacker_mutations) and (ctn.market_data.weather == ewcfg.weather_foggy) else 0
 
+    # double crit chance if TaS is active
     if ewcfg.mutation_id_threesashroud in attacker_mutations:
         allies_in_district = district_data.get_players_in_district(
             min_level=math.ceil((1 / 10) ** 0.25 * ctn.user_data.slimelevel),

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -1202,7 +1202,7 @@ def apply_attack_modifiers(ctn, hitzone, attacker_mutations, target_mutations, t
     ctn.slimes_damage *= attacker_status_mods['dmg'] * target_status_mods['dmg'] * misc_atk_mod * misc_def_mod
 
     # apply hit chance modifiers
-    ctn.hit_chance_mod += attacker_status_mods['hit_chance'] + target_status_mods['hit_chance'] - (5-ctn.user_data.weaponskill)/10 if ctn.user_data.weaponskill < 5 else 0
+    ctn.hit_chance_mod += attacker_status_mods['hit_chance'] + target_status_mods['hit_chance'] - ((5-ctn.user_data.weaponskill)/10 if ctn.user_data.weaponskill < 5 else 0)
 
     # lucky lucky lucy, oh and also n4 lol
     if ctn.shootee_data.life_state == ewcfg.life_state_lucky or target_status_mods['untouchable']:
@@ -1210,7 +1210,7 @@ def apply_attack_modifiers(ctn, hitzone, attacker_mutations, target_mutations, t
 
     # apply crit chance modifiers
     ctn.crit_mod += attacker_status_mods['crit'] + target_status_mods['crit'] + \
-        0.1 if (ewcfg.mutation_id_airlock in attacker_mutations or ewcfg.mutation_id_foghorn in attacker_mutations) and (ctn.market_data.weather == ewcfg.weather_foggy) else 0
+        (0.1 if (ewcfg.mutation_id_airlock in attacker_mutations or ewcfg.mutation_id_foghorn in attacker_mutations) and (ctn.market_data.weather == ewcfg.weather_foggy) else 0)
 
     # double crit chance if TaS is active
     if ewcfg.mutation_id_threesashroud in attacker_mutations:

--- a/ew/model/status.py
+++ b/ew/model/status.py
@@ -6,10 +6,10 @@ class EwStatusEffectDef:
     str_acquire = ""
     str_describe = ""
     str_describe_self = ""
-    dmg_mod_self = 0
+    dmg_mod_self = 1
     hit_chance_mod_self = 0
     crit_mod_self = 0
-    dmg_mod = 0
+    dmg_mod = 1
     hit_chance_mod = 0
     crit_mod = 0
 
@@ -20,10 +20,10 @@ class EwStatusEffectDef:
             str_acquire = "",
             str_describe = "",
             str_describe_self = "",
-            dmg_mod_self = 0,
+            dmg_mod_self = 1,
             hit_chance_mod_self = 0,
             crit_mod_self = 0,
-            dmg_mod = 0,
+            dmg_mod = 1,
             hit_chance_mod = 0,
             crit_mod = 0
     ):

--- a/ew/static/status.py
+++ b/ew/static/status.py
@@ -161,7 +161,7 @@ status_effect_list = [
         time_expire=300,
         str_acquire="Calorie-induced rage consumes you! You could drink gasoline and get shot and not feel a damn thing!",
         str_describe_self="You're in the middle of a raging food coma.",
-        dmg_mod=-0.4
+        dmg_mod=0.6
     ),
     EwStatusEffectDef(
         id_status=ewcfg.status_n1,
@@ -169,8 +169,8 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="You are god's gift to malice.",
         str_describe="He is god's gift to malice.",
-        dmg_mod=-0.5,
-        dmg_mod_self=1,
+        dmg_mod=0.5,
+        dmg_mod_self=2,
         hit_chance_mod_self=+.2,
         hit_chance_mod=-.35
     ),
@@ -180,9 +180,9 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="You shred like nobody's business.",
         str_describe="They shred like nobody's business.",
-        dmg_mod=-0.5,
-        hit_chance_mod_self=+.2,
-        hit_chance_mod=-.5
+        dmg_mod=0.5,
+        hit_chance_mod_self=0.2,
+        hit_chance_mod=-0.5
     ),
     EwStatusEffectDef(
         id_status=ewcfg.status_n4,
@@ -190,16 +190,16 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="Sorry, you can't let them do that.",
         str_describe="Sorry, they can't let you do this.",
-        dmg_mod=-1,
-        dmg_mod_self=-.5,
+        dmg_mod=0,
+        dmg_mod_self=0.5,
     ),
     EwStatusEffectDef(
         id_status=ewcfg.status_n8,
         time_expire=86400,
         str_acquire="",
         str_describe_self="You're itching to move on from this.",
-        dmg_mod_self=-0.5,
-        dmg_mod=0.5,
+        dmg_mod_self=0.5,
+        dmg_mod=1.5,
         crit_mod_self=.3
     ),
     EwStatusEffectDef(
@@ -208,9 +208,8 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="You're feeling like putting your cronies to the test.",
         str_describe="You're afraid of this guy.",
-        dmg_mod=-0.5,
-        dmg_mod_self=0.5,
-
+        dmg_mod=0.5,
+        dmg_mod_self=1.5,
         crit_mod_self=.5
     ),
     EwStatusEffectDef(
@@ -219,8 +218,8 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="Time to get nasty.",
         str_describe="She barely looks human.",
-        dmg_mod=-0.5,
-        dmg_mod_self=0.7,
+        dmg_mod=0.5,
+        dmg_mod_self=1.7,
         crit_mod_self=.75
     ),
     EwStatusEffectDef(
@@ -229,8 +228,8 @@ status_effect_list = [
         str_acquire="",
         str_describe_self="They're really starting to get on your nerves.",
         str_describe="You're really starting to get on his nerves.",
-        dmg_mod=-0.5,
-        dmg_mod_self=0.5,
+        dmg_mod=0.5,
+        dmg_mod_self=1.5,
         crit_mod_self=.5
     ),
 
@@ -245,7 +244,7 @@ status_effect_list = [
         time_expire=86400,
         str_acquire="",
         str_describe_self="You're dressed to the nines in the latest Kevlar work attire.",
-        dmg_mod=-0.2
+        dmg_mod=0.8
     ),
     EwStatusEffectDef(
         id_status=ewcfg.status_hogtied_id,
@@ -293,7 +292,7 @@ status_effect_list = [
         str_acquire="",
         str_describe="They look exceedingly difficult to kill.",
         str_describe_self="",
-        dmg_mod=-.8,
+        dmg_mod=0.2,
     ),
     EwStatusEffectDef(
         id_status=ewcfg.status_enemy_dodgy_id,

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -1016,7 +1016,7 @@ def get_hitzone(injury_map = None):
 # Returns the total modifier of all statuses of a certain type and target of a given player
 def get_shooter_status_mods(user_data = None, shootee_data = None, hitzone = None):
     mods = {
-        'dmg': 0,
+        'dmg': 1,
         'crit': 0,
         'hit_chance': 0,
         'no_cost': False,
@@ -1061,7 +1061,7 @@ def get_shooter_status_mods(user_data = None, shootee_data = None, hitzone = Non
                 mods['hit_chance'] += status_flavor.hit_chance_mod_self
             mods['crit'] += status_flavor.crit_mod_self
 
-            mods['dmg'] += status_flavor.dmg_mod_self
+            mods['dmg'] *= status_flavor.dmg_mod_self
 
     # Checks if any status mod in the nocost list is in the user's statuses
     if len(set(ewcfg.nocost).intersection(set(user_statuses))) > 0 or user_data.life_state == ewcfg.life_state_vigilante:
@@ -1076,7 +1076,7 @@ def get_shooter_status_mods(user_data = None, shootee_data = None, hitzone = Non
 # Returns the total modifier of all statuses of a certain type and target of a given player
 def get_shootee_status_mods(user_data = None, shooter_data = None, hitzone = None):
     mods = {
-        'dmg': 0,
+        'dmg': 1,
         'crit': 0,
         'hit_chance': 0,
         'untouchable': False
@@ -1100,7 +1100,7 @@ def get_shootee_status_mods(user_data = None, shooter_data = None, hitzone = Non
         if status_flavor is not None:
             mods['hit_chance'] += status_flavor.hit_chance_mod
             mods['crit'] += status_flavor.crit_mod
-            mods['dmg'] += status_flavor.dmg_mod
+            mods['dmg'] *= status_flavor.dmg_mod
 
     if ewcfg.status_n4 in user_statuses:
         mods['untouchable'] = True


### PR DESCRIPTION
 - Annoint now stops when telling the user they need a weapon
 - Status effect attack mods now apply the same way as all other attack mods. Damage mods are multiplicative, hit and crit mods are additive. Fixes potential for negative attack multiplier.