### PR TITLE
fix revival of users with near-identical duplicate rows

### DIFF
--- a/client.py
+++ b/client.py
@@ -1039,7 +1039,7 @@ async def on_message(message):
 
             poi = poi_static.id_to_poi.get(usermodel.poi)
             cmd_obj.guild = ewcfg.server_list[playermodel.id_server]
-            cmd_obj.message.author = cmd_obj.guild.get_member(playermodel.id_user)
+            cmd_obj.message.author = await fe_utils.get_member(cmd_obj.guild, playermodel.id_user)
 
             # Handle DM compatible commands
             if cmd in dm_cmd_map:

--- a/ew/backend/user.py
+++ b/ew/backend/user.py
@@ -90,6 +90,8 @@ class EwUserBase:
     """ fix data in this object if it's out of acceptable ranges """
 
     def limit_fix(self):
+        self.id_user = str(self.id_user)
+
         if self.hunger > self.get_hunger_max():
             self.hunger = self.get_hunger_max()
 
@@ -115,18 +117,18 @@ class EwUserBase:
         self.combatant_type = ewcfg.combatant_type_player
 
         if ew_id != None:
-            id_user = ew_id.user
+            id_user = str(ew_id.user)
             id_server = ew_id.guild
 
         if (id_user == None) and (id_server == None):
             if (member != None):
                 id_server = member.guild.id
-                id_user = member.id
+                id_user = str(member.id)
 
         # Retrieve the object from the database if the user is provided.
         if (id_user != None) and (id_server != None):
             self.id_server = id_server
-            self.id_user = id_user
+            self.id_user = str(id_user)
 
             try:
                 conn_info = bknd_core.databaseConnect()

--- a/ew/cmd/apt/aptcmds.py
+++ b/ew/cmd/apt/aptcmds.py
@@ -50,7 +50,7 @@ async def retire(cmd = None, isGoto = False, movecurrent = None):
     owner_user = None
     if cmd.mentions_count == 0 and cmd.tokens_count > 1 and isGoto == False:
         server = cmd.guild
-        member_object = server.get_member(ewutils.getIntToken(cmd.tokens))
+        member_object = await fe_utils.get_member(server, ewutils.getIntToken(cmd.tokens))
         owner_user = EwUser(member=member_object)
     elif cmd.mentions_count == 1:
         owner_user = EwUser(member=cmd.mentions[0])
@@ -98,7 +98,7 @@ async def depart(cmd = None, isGoto = False, movecurrent = None):
 
     client = ewutils.get_client()
     server = ewcfg.server_list[user_data.id_server]
-    member_object = server.get_member(user_data.id_user)
+    member_object = await fe_utils.get_member(server, user_data.id_user)
 
     if not poi_source.is_apartment:
         response = "You're not in an apartment."
@@ -352,7 +352,7 @@ async def knock(cmd = None):
     target_data = None
     if cmd.mentions_count == 0 and cmd.tokens_count > 1:
         server = ewcfg.server_list[user_data.id_server]
-        target = server.get_member(cmd.tokens[1])
+        target = await fe_utils.get_member(server, cmd.tokens[1])
         target_data = EwUser(member=target)
     elif cmd.mentions_count == 1:
         target = cmd.mentions[0]

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -358,7 +358,7 @@ async def data(cmd):
         if user_data.life_state == ewcfg.life_state_corpse:
             inhabitee_id = user_data.get_inhabitee()
             if inhabitee_id:
-                inhabitee_name = server.get_member(inhabitee_id).display_name
+                inhabitee_name = (await fe_utils.get_member(server, inhabitee_id)).display_name
                 possession = user_data.get_possession()
                 if possession:
                     if possession[3] == 'weapon':
@@ -372,7 +372,7 @@ async def data(cmd):
             if inhabitant_ids:
                 inhabitant_names = []
                 for inhabitant_id in inhabitant_ids:
-                    inhabitant_names.append(server.get_member(inhabitant_id).display_name)
+                    inhabitant_names.append((await fe_utils.get_member(server, inhabitant_id)).display_name)
 
                 possession = user_data.get_possession()
                 if possession is not None:
@@ -388,7 +388,7 @@ async def data(cmd):
                         inhabitant_names[-1]
                     )
                     if possession:
-                        response_block += "{} is also possessing your {}. ".format(server.get_member(ghost_in_weapon).display_name, possession_type)
+                        response_block += "{} is also possessing your {}. ".format((await fe_utils.get_member(server, ghost_in_weapon)).display_name, possession_type)
 
         # if user_data.swear_jar >= 500:
         # 	response_block += "You're going to The Underworld for the things you've said."
@@ -2879,11 +2879,11 @@ async def dual_key_ban(cmd):
     if cmd.mentions_count == 1:
         # Raw mentions so we can even grab the funny ones
         mention_id = cmd.message.raw_mentions[0]
-        member = cmd.message.guild.get_member(mention_id)
+        member = await fe_utils.get_member(cmd.message.guild, mention_id)
 
     if len(cmd.tokens) >= 2 and str.isnumeric(cmd.tokens[1]):
         mention_id = cmd.tokens[1]
-        member = cmd.message.guild.get_member(int(mention_id))
+        member = await fe_utils.get_member(cmd.message.guild, mention_id)
 
     if member is not None:
         # If the person you're trying to dualkey is also a mod/admin/etc.
@@ -2948,11 +2948,11 @@ async def dual_key_release(cmd):
     if cmd.mentions_count == 1:
         # Raw mentions so we can even grab the funny ones
         mention_id = cmd.message.raw_mentions[0]
-        member = cmd.message.guild.get_member(mention_id)
+        member = await fe_utils.get_member(cmd.message.guild, mention_id)
 
     if len(cmd.tokens) >= 2 and str.isnumeric(cmd.tokens[1]):
         mention_id = cmd.tokens[1]
-        member = cmd.message.guild.get_member(int(mention_id))
+        member = await fe_utils.get_member(cmd.message.guild, mention_id)
 
     if member is not None:
         # If the person you're trying to dualkey is also a mod/admin/etc.

--- a/ew/cmd/district/districtcmds.py
+++ b/ew/cmd/district/districtcmds.py
@@ -136,7 +136,7 @@ async def ufo_observe(cmd):
                 players_in_district = district_data.get_players_in_district(min_slimes=0, life_states=[ewcfg.life_state_enlisted, ewcfg.life_state_corpse, ewcfg.life_state_juvenile], ignore_offline=True)
                 server = ewcfg.server_list[cmd.guild.id]
                 for playerid in players_in_district:
-                    member_object = server.get_member(playerid)
+                    member_object = await fe_utils.get_member(server, playerid)
                     await ewrolemgr.updateRoles(client=cmd.client, member=member_object)
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 

--- a/ew/cmd/fish/fishutils.py
+++ b/ew/cmd/fish/fishutils.py
@@ -312,7 +312,7 @@ async def award_fish(fisher, cmd, user_data):
                 player_id = random.choice(players_in_district)
 
                 target_data = EwUser(id_user=player_id, id_server=cmd.guild.id)
-                target = cmd.guild.get_member(player_id)
+                target = await ewfrontend.get_member(cmd.guild, player_id)
 
                 mutations = target_data.get_mutations()
 
@@ -481,10 +481,10 @@ async def award_fish(fisher, cmd, user_data):
 
         if fisher.inhabitant_id:
             server = cmd.guild
-            inhabitant_member = server.get_member(fisher.inhabitant_id)
+            inhabitant_member = await ewfrontend.get_member(server, fisher.inhabitant_id)
             inhabitant_name = inhabitant_member.display_name
             inhabitant_data = EwUser(id_user=fisher.inhabitant_id, id_server=user_data.id_server)
-            inhabitee_name = server.get_member(actual_fisherman).display_name
+            inhabitee_name = (await ewfrontend.get_member(server, actual_fisherman)).display_name
 
             # Take 1/4 of the slime the player would have gained, to inverse and give to the ghost.
             slime_gain = int(0.25 * slime_gain)        

--- a/ew/cmd/kingpin/kingpincmds.py
+++ b/ew/cmd/kingpin/kingpincmds.py
@@ -548,7 +548,7 @@ async def clowncar(cmd):#shoves everyone not there into JR or the sewers
         phone_data.item_props['gellphoneactive'] = 'false'
         phone_data.persist()
         if phone_data.id_owner.isnumeric() and int(phone_data.id_owner)>0:
-            member_object = server.get_member(int(phone_data.id_owner))
+            member_object = await fe_utils.get_member(server, phone_data.id_owner)
             if member_object is None:
                 continue
             user_data = EwUser(member=member_object)
@@ -582,7 +582,7 @@ async def clowncar(cmd):#shoves everyone not there into JR or the sewers
                 iterator += 1
                 if iterator % 20 == 0:
                     await asyncio.sleep(5)
-                member_object = server.get_member(member[0])
+                member_object = await fe_utils.get_member(server, member[0])
                 await ewrolemgr.updateRoles(client = cmd.client, member=member_object)
 
 

--- a/ew/cmd/move/movecmds.py
+++ b/ew/cmd/move/movecmds.py
@@ -840,7 +840,7 @@ async def scout(cmd):
                 if len(allies_in_district) > 3:
                     continue
             if ewcfg.mutation_id_chameleonskin in scoutee_mutations:
-                member = cmd.guild.get_member(scoutee_data.id_user)
+                member = await fe_utils.get_member(cmd.guild, scoutee_data.id_user)
                 if member == None or member.status == discord.Status.offline:
                     continue
 
@@ -1320,7 +1320,7 @@ async def flush_streets(cmd):
                 user_data = EwUser(id_user=player, id_server=cmd.guild.id)
                 user_data.poi = ewcfg.poi_id_juviesrow
                 user_data.persist()
-                member = cmd.guild.get_member(player)
+                member = await fe_utils.get_member(cmd.guild, player)
                 await ewrolemgr.updateRoles(client=cmd.client, member=member)
 
             item_cache = bknd_core.get_cache(obj_type = "EwItem")

--- a/ew/cmd/move/moveutils.py
+++ b/ew/cmd/move/moveutils.py
@@ -320,7 +320,7 @@ async def one_eye_dm(id_user = None, id_server = None, poi = None):
                     str(id_user),
                 ))
             for recipient in recipients:
-                member = server.get_member(int(recipient[0]))
+                member = await fe_utils.get_member(server, recipient[0])
                 mutation = EwMutation(id_server=id_server, id_user=recipient[0], id_mutation=ewcfg.mutation_id_oneeyeopen)
                 mutation.data = ""
                 mutation.persist()

--- a/ew/cmd/quadrants/quadrantcmds.py
+++ b/ew/cmd/quadrants/quadrantcmds.py
@@ -77,11 +77,11 @@ async def clear_quadrant(cmd):
     quadrant_data = EwQuadrant(id_server=author.guild.id, id_user=author.id, quadrant=quadrant.id_quadrant)
 
     if quadrant_data.id_target != -1:
-        target_member_data = cmd.guild.get_member(quadrant_data.id_target)
+        target_member_data = await fe_utils.get_member(cmd.guild, quadrant_data.id_target)
         target_member_data_2 = None
 
         if quadrant_data.id_target2 != -1:
-            target_member_data_2 = cmd.guild.get_member(quadrant_data.id_target)
+            target_member_data_2 = await fe_utils.get_member(cmd.guild, quadrant_data.id_target)
 
         quadrant_data = EwQuadrant(id_server=author.guild.id, id_user=author.id, quadrant=quadrant.id_quadrant, id_target=-1, id_target2=-1)
         quadrant_data.persist()
@@ -107,7 +107,7 @@ async def get_quadrants(cmd):
         quadrant_data = EwQuadrant(id_server=cmd.guild.id, id_user=member.id, quadrant=quadrant)
         if quadrant_data.id_target != -1:
             response += "\n"
-            response += get_quadrant(cmd, quadrant)
+            response += await get_quadrant(cmd, quadrant)
 
     if response == "":
         response = "{} quadrants are completely empty. " + ewcfg.emote_broken_heart
@@ -129,24 +129,24 @@ async def get_quadrants(cmd):
 
 
 async def get_sloshed(cmd):
-    response = get_quadrant(cmd, ewcfg.quadrant_sloshed)
+    response = await get_quadrant(cmd, ewcfg.quadrant_sloshed)
 
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
 
 async def get_roseate(cmd):
-    response = get_quadrant(cmd, ewcfg.quadrant_roseate)
+    response = await get_quadrant(cmd, ewcfg.quadrant_roseate)
 
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
 
 async def get_violacious(cmd):
-    response = get_quadrant(cmd, ewcfg.quadrant_violacious)
+    response = await get_quadrant(cmd, ewcfg.quadrant_violacious)
 
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
 
 
 async def get_policitous(cmd):
-    response = get_quadrant(cmd, ewcfg.quadrant_policitous)
+    response = await get_quadrant(cmd, ewcfg.quadrant_policitous)
 
     return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))

--- a/ew/cmd/quadrants/quadrantutils.py
+++ b/ew/cmd/quadrants/quadrantutils.py
@@ -1,16 +1,17 @@
 from ew.backend.quadrants import EwQuadrant
 from ew.static import cfg as ewcfg
 from ew.static import quadrants as quad_static
+from ew.utils import frontend as fe_utils
 
 
-def get_quadrant(cmd, id_quadrant):
+async def get_quadrant(cmd, id_quadrant):
     author = cmd.message.author
     quadrant = quad_static.quadrants_map[id_quadrant]
     if cmd.mentions_count == 0:
         quadrant_data = EwQuadrant(id_server=author.guild.id, id_user=author.id, quadrant=quadrant.id_quadrant)
-        if author.guild.get_member(quadrant_data.id_target) is None:
+        if await fe_utils.get_member(author.guild, quadrant_data.id_target) is None:
             quadrant_data.id_target = -1
-        if author.guild.get_member(quadrant_data.id_target2) is None:
+        if await fe_utils.get_member(author.guild, quadrant_data.id_target2) is None:
             quadrant_data.id_target2 = -1
 
         quadrant_data.persist()
@@ -21,9 +22,9 @@ def get_quadrant(cmd, id_quadrant):
             onesided = quadrant_data.check_if_onesided()
 
             if quadrant.id_quadrant == ewcfg.quadrant_policitous and quadrant_data.id_target2 != -1:
-                target_name = "{} and {}".format(author.guild.get_member(quadrant_data.id_target).display_name, author.guild.get_member(quadrant_data.id_target2).display_name)
+                target_name = "{} and {}".format((await fe_utils.get_member(author.guild, quadrant_data.id_target)).display_name, (await fe_utils.get_member(author.guild, quadrant_data.id_target2)).display_name)
             else:
-                target_name = author.guild.get_member(quadrant_data.id_target).display_name
+                target_name = (await fe_utils.get_member(author.guild, quadrant_data.id_target)).display_name
 
             if not onesided:
                 response = quadrant.resp_view_relationship_self.format(target_name)
@@ -34,9 +35,9 @@ def get_quadrant(cmd, id_quadrant):
         member = cmd.mentions[0]
         quadrant_data = EwQuadrant(id_server=member.guild.id, id_user=member.id, quadrant=quadrant.id_quadrant)
 
-        if author.guild.get_member(quadrant_data.id_target) is None:
+        if await fe_utils.get_member(author.guild, quadrant_data.id_target) is None:
             quadrant_data.id_target = -1
-        if author.guild.get_member(quadrant_data.id_target2) is None:
+        if await fe_utils.get_member(author.guild, quadrant_data.id_target2) is None:
             quadrant_data.id_target2 = -1
 
         quadrant_data.persist()
@@ -48,9 +49,9 @@ def get_quadrant(cmd, id_quadrant):
             onesided = quadrant_data.check_if_onesided()
 
             if quadrant.id_quadrant == ewcfg.quadrant_policitous and quadrant_data.id_target2 != -1:
-                target_name = "{} and {}".format(author.guild.get_member(quadrant_data.id_target).display_name, author.guild.get_member(quadrant_data.id_target2).display_name)
+                target_name = "{} and {}".format((await fe_utils.get_member(author.guild, quadrant_data.id_target)).display_name, (await fe_utils.get_member(author.guild, quadrant_data.id_target2)).display_name)
             else:
-                target_name = author.guild.get_member(quadrant_data.id_target).display_name
+                target_name = (await fe_utils.get_member(author.guild, quadrant_data.id_target)).display_name
 
             if not onesided:
                 response = quadrant.resp_view_relationship.format(member.display_name, target_name)

--- a/ew/cmd/raidboss/raidbosscmds.py
+++ b/ew/cmd/raidboss/raidbosscmds.py
@@ -73,7 +73,7 @@ async def writhe(cmd):
                 # convert pulled IDs into member objects
                 target_ids = cursor.fetchall()
                 for target_id in target_ids:
-                    target = cmd.guild.get_member(target_id[0])
+                    target = await fe_utils.get_member(cmd.guild, target_id[0])
                     targets.append(target)
 
                 conn.commit()

--- a/ew/cmd/spooky/spookycmds.py
+++ b/ew/cmd/spooky/spookycmds.py
@@ -195,7 +195,7 @@ async def haunt(cmd):
         member = None
         if cmd.mentions_count == 0 and cmd.tokens_count > 1:
             server = cmd.guild
-            member = server.get_member(ewutils.getIntToken(cmd.tokens))
+            member = await fe_utils.get_member(server, ewutils.getIntToken(cmd.tokens))
             haunted_data = EwUser(member=member)
         elif cmd.mentions_count == 1:
             member = cmd.mentions[0]
@@ -441,7 +441,7 @@ async def possess_weapon(cmd):
         server = cmd.guild
         inhabitee_id = user_data.get_inhabitee()
         inhabitee_data = EwUser(id_user=inhabitee_id, id_server=user_data.id_server)
-        inhabitee_member = server.get_member(inhabitee_id)
+        inhabitee_member = await fe_utils.get_member(server, inhabitee_id)
         inhabitee_name = inhabitee_member.display_name
         if inhabitee_data.weapon < 0:
             response = "{} is not wielding a weapon right now.".format(inhabitee_name)
@@ -500,7 +500,7 @@ async def possess_fishing_rod(cmd):
         server = cmd.guild
         inhabitee_id = user_data.get_inhabitee()
         inhabitee_data = EwUser(id_user=inhabitee_id, id_server=user_data.id_server)
-        inhabitee_member = server.get_member(inhabitee_id)
+        inhabitee_member = await fe_utils.get_member(server, inhabitee_id)
         inhabitee_name = inhabitee_member.display_name
         if inhabitee_data.get_possession():
             response = "{} is already being possessed.".format(inhabitee_name)

--- a/ew/cmd/wep/wepcmds.py
+++ b/ew/cmd/wep/wepcmds.py
@@ -154,7 +154,7 @@ async def attack(cmd):
 
             # Apply mass burn from incendiary weapons
             if ctn.mass_apply_status == ewcfg.status_burning_id:
-                mass_status = apply_status_bystanders(
+                mass_status = await apply_status_bystanders(
                     user_data=attacker, status=ewcfg.status_burning_id,
                     value=ctn.bystander_damage, life_states=[ewcfg.life_state_enlisted, ewcfg.life_state_juvenile, ewcfg.life_state_executive, ewcfg.life_state_vigilante],
                     factions=["", target.faction], district_data=district_data
@@ -397,7 +397,7 @@ async def attack(cmd):
                 bounty_resp = "\n\n SlimeCorp transfers {:,} SlimeCoin to {}\'s account.".format(bounty, attacker_member.display_name)
 
             if possession:
-                ghost_name = cmd.guild.get_member(possession[0]).display_name
+                ghost_name = (await fe_utils.get_member(cmd.guild, possession[0])).display_name
                 contract_resp = "\n\n {} winces in pain as their slime is corrupted into negaslime. {}'s contract has been fulfilled.".format(attacker_member.display_name, ghost_name)
 
             if random.randint(0, 99) == 0 and target.gender != 'gorl':
@@ -521,7 +521,7 @@ async def attack(cmd):
         """ Final Operations """
 
         # Fulfill possession if necessary
-        if possession: fulfill_ghost_weapon_contract(possession, market_data, attacker, attacker_member.display_name)
+        if possession: await fulfill_ghost_weapon_contract(possession, market_data, attacker, attacker_member.display_name)
 
         # Persist everything that may have been changed. RIP function completion time
         if not possession: district_data.persist() # this is changed and persisted within fulfillment, no need to do it twice

--- a/ew/cmd/wep/weputils.py
+++ b/ew/cmd/wep/weputils.py
@@ -107,7 +107,7 @@ class EwEffectContainer:
 # self.sap_ignored = sap_ignored
 
 
-def apply_status_bystanders(user_data = None, value = 0, life_states = None, factions = None, district_data = None, status = None):
+async def apply_status_bystanders(user_data = None, value = 0, life_states = None, factions = None, district_data = None, status = None):
     if life_states != None and factions != None and district_data != None and status != None:
         bystander_users = district_data.get_players_in_district(life_states=life_states, factions=factions, pvp_only=True)
         resp_cont = EwResponseContainer(id_server=user_data.id_server)
@@ -119,7 +119,7 @@ def apply_status_bystanders(user_data = None, value = 0, life_states = None, fac
             bystander_user_data = EwUser(id_user=bystander, id_server=user_data.id_server)
             bystander_player_data = EwPlayer(id_user=bystander, id_server=user_data.id_server)
             if bystander_player_data.display_name in ["", None]:
-                player_update(guild.get_member(bystander), guild)
+                player_update(await fe_utils.get_member(guild, bystander), guild)
             bystander_mutation = bystander_user_data.get_mutations()
 
             if market_data.weather == ewcfg.weather_rainy and status == ewcfg.status_burning_id:
@@ -290,7 +290,7 @@ async def weapon_explosion(user_data = None, shootee_data = None, district_data 
 
                     resp_cont.add_channel_response(channel, response)
 
-                    resp_cont.add_member_to_update(server.get_member(target_data.id_user))
+                    resp_cont.add_member_to_update(await fe_utils.get_member(server, target_data.id_user))
                 # Survived the explosion
                 else:
 
@@ -390,7 +390,7 @@ async def weapon_explosion(user_data = None, shootee_data = None, district_data 
         return resp_cont
 
 
-def fulfill_ghost_weapon_contract(possession_data, market_data, user_data, user_name):
+async def fulfill_ghost_weapon_contract(possession_data, market_data, user_data, user_name):
     ghost_id = possession_data[0]
     ghost_data = EwUser(id_user=ghost_id, id_server=user_data.id_server)
 
@@ -406,7 +406,7 @@ def fulfill_ghost_weapon_contract(possession_data, market_data, user_data, user_
     user_data.cancel_possession()
 
     server = ewutils.get_client().get_guild(user_data.id_server)
-    ghost_name = server.get_member(ghost_id).display_name
+    ghost_name = (await fe_utils.get_member(server, ghost_id)).display_name
     return "\n\n {} winces in pain as their slime is corrupted into negaslime. {}'s contract has been fulfilled.".format(user_name, ghost_name)
 
 
@@ -775,7 +775,7 @@ async def attackEnemy(cmd):
             # Burn players in district
             if ewcfg.weapon_class_burning in weapon.classes:
                 if not miss:
-                    resp = apply_status_bystanders(user_data=user_data, status=ewcfg.status_burning_id, value=bystander_damage, life_states=life_states, factions=factions, district_data=district_data)
+                    resp = await apply_status_bystanders(user_data=user_data, status=ewcfg.status_burning_id, value=bystander_damage, life_states=life_states, factions=factions, district_data=district_data)
                     resp_cont.add_response_container(resp)
 
             if ewcfg.weapon_class_exploding in weapon.classes:
@@ -965,7 +965,7 @@ async def attackEnemy(cmd):
 
         weapon_possession = user_data.get_possession('weapon')
         if weapon_possession:
-            response += fulfill_ghost_weapon_contract(weapon_possession, market_data, user_data, cmd.message.author.display_name)
+            response += await fulfill_ghost_weapon_contract(weapon_possession, market_data, user_data, cmd.message.author.display_name)
 
         # When a raid boss dies, use this response instead so its drops aren't shown in the killfeed
         old_response = response

--- a/ew/utils/apt.py
+++ b/ew/utils/apt.py
@@ -49,7 +49,7 @@ async def rent_time(id_server = None):
                         user_data.poi = user_apt.poi  # toss out player
                         user_data.persist()
                         server = ewcfg.server_list[user_data.id_server]
-                        member_object = server.get_member(owner_id_user)
+                        member_object = await fe_utils.get_member(server, owner_id_user)
 
                         await ewrolemgr.updateRoles(client=client, member=member_object)
                         player = EwPlayer(id_user=owner_id_user)
@@ -96,7 +96,7 @@ async def handle_hourly_events(id_server = None):
                         brick_obj = EwItem(id_item=we.event_props.get("brick_id"))
                         id_user = brick_obj.id_owner.replace("stomach", "")
                         brick_user = EwUser(id_server=id_server, id_user=id_user)
-                        brick_member = server.get_member(int(id_user))
+                        brick_member = await fe_utils.get_member(server, id_user)
                         poi = poi_static.id_to_poi.get(brick_user.poi)
                         channel_brick = fe_utils.get_channel(server, poi.channel)
                         if brick_member:
@@ -116,7 +116,7 @@ async def handle_hourly_events(id_server = None):
                         if "decorate" in clock_obj.id_owner:
                             isFurnished = True
                         clock_user = clock_obj.id_owner.replace("decorate", "")
-                        clock_member = server.get_member(clock_user)
+                        clock_member = await fe_utils.get_member(server, clock_user)
                         if clock_member != None:
                             clock_player = EwUser(member=clock_member)
                             if (isFurnished == False or ("apt" in clock_player.poi and clock_player.visiting == "empty")) and clock_member:
@@ -148,7 +148,7 @@ async def toss_squatters(user_id = None, server_id = None, keepKeys = False):
     client = ewutils.get_client()
     server = client.get_guild(server_id)
 
-    member_data = server.get_member(player_info.id_user)
+    member_data = await fe_utils.get_member(server, player_info.id_user)
 
     if player_info.id_server != None and member_data != None:
         try:
@@ -177,7 +177,7 @@ async def toss_squatters(user_id = None, server_id = None, keepKeys = False):
                     pass
                 else:
                     server = ewcfg.server_list[sqt_data.id_server]
-                    member_object = server.get_member(squatter[0])
+                    member_object = await fe_utils.get_member(server, squatter[0])
                     sqt_data.poi = sqt_data.poi[3:] if sqt_data.poi[3:] in poi_static.id_to_poi.keys() else sqt_data.poi
                     sqt_data.visiting = ewcfg.location_id_empty
                     sqt_data.persist()

--- a/ew/utils/combat.py
+++ b/ew/utils/combat.py
@@ -948,7 +948,7 @@ async def explode(damage = 0, district_data = None, market_data = None):
                 player_data.display_name)
             resp_cont.add_channel_response(channel, response)
 
-            resp_cont.add_member_to_update(server.get_member(user_data.id_user))
+            resp_cont.add_member_to_update(await fe_utils.get_member(server, user_data.id_user))
         else:
             # survive
             slime_splatter = 0.5 * slimes_damage
@@ -1826,7 +1826,7 @@ class EwUser(EwUserBase):
         member: EwPlayer = EwPlayer(id_server=self.id_server, id_user=self.id_user)
 
         # Make The death report
-        deathreport = fe_utils.create_death_report(cause=cause, user_data=self, deathmessage = deathmessage)
+        deathreport = await fe_utils.create_death_report(cause=cause, user_data=self, deathmessage = deathmessage)
         resp_cont.add_channel_response(ewcfg.channel_sewers, deathreport)
 
         poi = poi_static.id_to_poi.get(self.poi)
@@ -1983,7 +1983,7 @@ class EwUser(EwUserBase):
         ewutils.logMsg(f'Server {server.name} ({server.id}): {member.display_name} ({self.id_user}) was killed by {self.id_killer} - cause was {cause}')
         # You can opt out of the heavy roles update
         if updateRoles:
-            await ewrolemgr.updateRoles(client, server.get_member(self.id_user))
+            await ewrolemgr.updateRoles(client, await fe_utils.get_member(server, self.id_user))
 
         return resp_cont
 
@@ -2501,7 +2501,7 @@ class EwUser(EwUserBase):
                 ghost_data.time_lastenter = int(time.time())
                 ghost_data.persist()
 
-                ghost_member = server.get_member(ghost)
+                ghost_member = await fe_utils.get_member(server, ghost)
                 await ewrolemgr.updateRoles(client=client, member=ghost_member)
 
     def remove_inhabitation(self):

--- a/ew/utils/core.py
+++ b/ew/utils/core.py
@@ -741,13 +741,16 @@ def is_player_inventory(id_inventory, id_server):
 
     # Grab the Discord Client
     client = get_client()
-    discord_result = client.get_guild(id_server).get_member(id_inventory)
+    try:
+        discord_result = client.get_guild(id_server).get_member(int(id_inventory))
+    except ValueError:
+        return False    # Could not convert to int, so definitely not a player
 
     # Try to grab a value from a user with given id
     db_result = bknd_core.execute_sql_query("SELECT {} FROM users WHERE id_user = %s AND id_server = %s".format(
         ewcfg.col_rand_seed
     ), (
-        id_inventory,
+        str(id_inventory),
         id_server
     ))
 

--- a/ew/utils/district.py
+++ b/ew/utils/district.py
@@ -106,7 +106,7 @@ class EwDistrict(EwDistrictBase):
             faction = player[3]
             life_state = player[4]
 
-            member = server.get_member(id_user)
+            member = server.get_member(int(id_user))
 
             if member != None:
                 if max_level >= slimelevel >= min_level \

--- a/ew/utils/district.py
+++ b/ew/utils/district.py
@@ -106,7 +106,10 @@ class EwDistrict(EwDistrictBase):
             faction = player[3]
             life_state = player[4]
 
-            member = server.get_member(int(id_user))
+            try:
+                member = server.get_member(int(id_user))
+            except ValueError:
+                member = None
 
             if member != None:
                 if max_level >= slimelevel >= min_level \

--- a/ew/utils/loop.py
+++ b/ew/utils/loop.py
@@ -318,7 +318,7 @@ async def kill_quitters(id_server):
     ))
 
     for user in users:
-        member = server.get_member(user[0])
+        member = await fe_utils.get_member(server, user[0])
 
         # Make sure to kill players who may have left while the bot was offline.
         if member is None:
@@ -368,7 +368,7 @@ async def bleedSlimes(id_server):
         user_data = EwUser(id_user=user[0], id_server=id_server)
 
         mutations = user_data.get_mutations()
-        member = server.get_member(user_data.id_user)
+        member = await fe_utils.get_member(server, user_data.id_user)
         if ewcfg.mutation_id_bleedingheart not in mutations or user_data.time_lasthit < int(time.time()) - ewcfg.time_bhbleed:
             slimes_to_bleed = user_data.bleed_storage * (
                     1 - .5 ** (ewcfg.bleed_tick_length / ewcfg.bleed_half_life))
@@ -1122,7 +1122,7 @@ async def capture_tick(id_server):
 
                 # dont count offline players
                 try:
-                    player_online = server.get_member(int(player_id)).status != discord.Status.offline
+                    player_online = (await fe_utils.get_member(server, player_id)).status != discord.Status.offline
                 except:
                     player_online = False
 

--- a/ew/utils/loop.py
+++ b/ew/utils/loop.py
@@ -1122,7 +1122,7 @@ async def capture_tick(id_server):
 
                 # dont count offline players
                 try:
-                    player_online = server.get_member(player_id).status != discord.Status.offline
+                    player_online = server.get_member(int(player_id)).status != discord.Status.offline
                 except:
                     player_online = False
 
@@ -1145,7 +1145,6 @@ async def capture_tick(id_server):
                         if ewcfg.mutation_id_unnaturalcharisma in mutations:
                             player_capture_speed += 1
 
-                        #ewutils.logMsg("Adding {} to Capture Speed of {} for player {}".format(player_capture_speed, capture_speed, player_id))
                         capture_speed += player_capture_speed
                         num_capturers += 1
                         dc_stat_increase_list.append(player_id)

--- a/ew/utils/move.py
+++ b/ew/utils/move.py
@@ -576,7 +576,7 @@ async def kick(id_server):
                     if user_data.poi != party_poi and user_data.life_state not in [ewcfg.life_state_kingpin, ewcfg.life_state_lucky, ewcfg.life_state_executive]:
 
                         server = ewcfg.server_list[id_server]
-                        member_object = server.get_member(id_user)
+                        member_object = await fe_utils.get_member(server, id_user)
 
                         user_data.poi = mother_district_chosen
                         user_data.time_lastenter = int(time.time())

--- a/ew/utils/prank.py
+++ b/ew/utils/prank.py
@@ -34,7 +34,7 @@ async def activate_trap_items(district, id_server, id_user):
         district_channel_name = poi_static.id_to_poi.get(district).channel
         client = ewutils.get_client()
         server = client.get_guild(id_server)
-        member = server.get_member(id_user)
+        member = await fe_utils.get_member(server, id_user)
         district_channel = fe_utils.get_channel(server=server, channel_name=district_channel_name)
         searched_id = district + '_trap'
         item_cache = bknd_core.get_cache(obj_type = "EwItem")

--- a/ew/utils/weather.py
+++ b/ew/utils/weather.py
@@ -149,7 +149,7 @@ async def weather_tick(id_server = None):
 
                             # The member of the user
                             guild = client.get_guild(id_server)
-                            member = guild.get_member(user_data.id_user)
+                            member = await fe_utils.get_member(guild, user_data.id_user)
                             # Stop movement
                             ewutils.moves_active[user_data.id_user] = 0
                             await rutils.movement_checker(user_data, poi_static.id_to_poi.get(user_data.poi), deposited_district)


### PR DESCRIPTION
May be a bit overkill to have cast every possible assignment and add it as a limit fix, but this way it will be guaranteed to be a string no matter how it is input to the EwUser, which should give it consistent behavior. Without this commit, zug couldn't revive, with it Zug could. Not sure how exactly revival was being blocked, but this fixes it.