### PR TITLE
Bigger Fixes

### DIFF
--- a/ew/backend/apt.py
+++ b/ew/backend/apt.py
@@ -52,13 +52,15 @@ class EwApartment:
             elif id_server is not None and id_user is not None:
                 # Create a new database entry if the object is missing.
                 bknd_core.execute_sql_query(
-                    sql_query = "REPLACE INTO apartment({}, {}) VALUES(%s, %s)".format(
-                    ewcfg.col_id_user,
-                    ewcfg.col_id_server
+                    sql_query = "REPLACE INTO apartment({}, {}, {}) VALUES(%s, %s, %s)".format(
+                        ewcfg.col_id_user,
+                        ewcfg.col_id_server,
+                        ewcfg.col_poi
                     ), 
                     sql_replacements = (
-                    self.id_user,
-                    self.id_server
+                        self.id_user,
+                        self.id_server,
+                        self.poi
                     )
                 )
 

--- a/ew/backend/apt.py
+++ b/ew/backend/apt.py
@@ -8,7 +8,7 @@ class EwApartment:
 
     name = "a city apartment."
     description = "It's drafty in here! You briefly consider moving out, but your SlimeCoin is desperate to leave your pocket."
-    poi = "downtown"
+    poi = ""
     rent = 0
     apt_class = "c"
     num_keys = 0
@@ -24,13 +24,8 @@ class EwApartment:
             self.id_user = id_user
             self.id_server = id_server
 
-            try:
-                conn_info = bknd_core.databaseConnect()
-                conn = conn_info.get('conn')
-                cursor = conn.cursor()
-
-                # Retrieve object
-                cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM apartment WHERE id_user = %s and id_server = %s".format(
+            result = bknd_core.execute_sql_query(
+                sql_query = "SELECT {}, {}, {}, {}, {}, {}, {}, {} FROM apartment WHERE id_user = %s and id_server = %s".format(
                     ewcfg.col_apt_name,
                     ewcfg.col_apt_description,
                     ewcfg.col_poi,
@@ -39,36 +34,33 @@ class EwApartment:
                     ewcfg.col_num_keys,
                     ewcfg.col_key_1,
                     ewcfg.col_key_2
+                ),
+                sql_replacements = (self.id_user, self.id_server),
+                fetchone = True
+            )
 
-                ), (self.id_user,
-                    self.id_server))
-                result = cursor.fetchone();
-
-                if result != None:
-                    # Record found: apply the data to this object.
-                    self.name = result[0]
-                    self.description = result[1]
-                    self.poi = result[2]
-                    self.rent = result[3]
-                    self.apt_class = result[4]
-                    self.num_keys = result[5]
-                    self.key_1 = result[6]
-                    self.key_2 = result[7]
-                elif id_server != None:
-                    # Create a new database entry if the object is missing.
-                    cursor.execute("REPLACE INTO apartment({}, {}) VALUES(%s, %s)".format(
-                        ewcfg.col_id_user,
-                        ewcfg.col_id_server
-                    ), (
-                        self.id_user,
-                        self.id_server
-                    ))
-
-                    conn.commit()
-            finally:
-                # Clean up the database handles.
-                cursor.close()
-                bknd_core.databaseClose(conn_info)
+            if result != None:
+                # Record found: apply the data to this object.
+                self.name = result[0]
+                self.description = result[1]
+                self.poi = result[2]
+                self.rent = result[3]
+                self.apt_class = result[4]
+                self.num_keys = result[5]
+                self.key_1 = result[6]
+                self.key_2 = result[7]
+            elif id_server is not None and id_user is not None:
+                # Create a new database entry if the object is missing.
+                bknd_core.execute_sql_query(
+                    sql_query = "REPLACE INTO apartment({}, {}) VALUES(%s, %s)".format(
+                    ewcfg.col_id_user,
+                    ewcfg.col_id_server
+                    ), 
+                    sql_replacements = (
+                    self.id_user,
+                    self.id_server
+                    )
+                )
 
     def persist(self):
         bknd_core.execute_sql_query(

--- a/ew/backend/core.py
+++ b/ew/backend/core.py
@@ -386,7 +386,7 @@ def databaseClose(conn_info):
 """
 
 
-def execute_sql_query(sql_query = None, sql_replacements = None, fetchone = False):
+def execute_sql_query(sql_query = None, sql_replacements = None, fetchone = False, lastrowid = False):
     data = None
     cursor = None
     conn_info = None
@@ -396,9 +396,15 @@ def execute_sql_query(sql_query = None, sql_replacements = None, fetchone = Fals
         conn = conn_info.get('conn')
         cursor = conn.cursor()
         cursor.execute(sql_query, sql_replacements)
+
         if sql_query.lower().startswith("select"):
             data = cursor.fetchall() if not fetchone else cursor.fetchone()
+
+        if sql_query.lower().startswith("insert") and lastrowid:
+            data = cursor.lastrowid
+
         conn.commit()
+
     finally:
         # Clean up the database handles.
         if cursor is not None: cursor.close()

--- a/ew/backend/goonscapestats.py
+++ b/ew/backend/goonscapestats.py
@@ -182,8 +182,8 @@ class EwGoonScapeStat:
                         'fashion_style': ewcfg.style_skill,
                         'freshness': 0,
                         'adorned': 'true',
-                        'soulbound': 'true'
-                    }
+                    },
+                    soulbound=True
                 )
                 await create_quest_record(int(time.time()), self.id_user, self.id_server, "skill_cape", self.stat)
 

--- a/ew/backend/item.py
+++ b/ew/backend/item.py
@@ -315,8 +315,6 @@ def item_create(
 ):
 
     item_def = static_items.item_def_map.get(item_type)
-    if soulbound is not None:
-        item_def.soulbound = soulbound
     badRelic = 0
 
     if item_def == None:
@@ -368,7 +366,7 @@ def item_create(
                 item_type,
                 id_user,
                 id_server,
-                (1 if item_def.soulbound else 0),
+                (1 if (item_def.soulbound if soulbound is None else soulbound) else 0),
                 stack_max,
                 stack_size,
                 template_id,

--- a/ew/cmd/apt/aptcmds.py
+++ b/ew/cmd/apt/aptcmds.py
@@ -58,15 +58,15 @@ async def retire(cmd = None, isGoto = False, movecurrent = None):
         return await usekey(cmd, owner_user)
     if cmd.message.guild is None or not ewutils.channel_name_is_poi(cmd.message.channel.name):
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, "You must {} in a zone's channel.".format(cmd.tokens[0])))
+    elif apt_data.rent == 0:
+        response = "You don't *have* an apartment, dumbass."
+        return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
     elif ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
         response = "You can't do that right now."
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
     elif apt_zone != poi.id_poi:
         response = "You don't own an apartment here."
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
-    elif apt_data.rent == 0:
-        response = "You don't *have* an apartment, dumbass."
-        return await fe_utils.semd_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
     else:
         if isGoto:
             move_current = movecurrent

--- a/ew/cmd/apt/aptcmds.py
+++ b/ew/cmd/apt/aptcmds.py
@@ -44,7 +44,6 @@ async def retire(cmd = None, isGoto = False, movecurrent = None):
     apt_data = EwApartment(id_server=cmd.guild.id, id_user=cmd.message.author.id)
     apt_zone = apt_data.poi
 
-
     poi_dest = poi_static.id_to_poi.get(ewcfg.poi_id_apt + apt_zone)  # there isn't an easy way to change this, apologies for being a little hacky
 
     owner_user = None
@@ -65,6 +64,9 @@ async def retire(cmd = None, isGoto = False, movecurrent = None):
     elif apt_zone != poi.id_poi:
         response = "You don't own an apartment here."
         return await fe_utils.send_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
+    elif apt_data.rent == 0:
+        response = "You don't *have* an apartment, dumbass."
+        return await fe_utils.semd_message(cmd.client, cmd.message.channel, fe_utils.formatMessage(cmd.message.author, response))
     else:
         if isGoto:
             move_current = movecurrent

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -3567,8 +3567,8 @@ async def award_skill_capes(cmd): #this command should be removed after its been
                     'fashion_style': ewcfg.style_skill,
                     'freshness': 0,
                     'adorned': 'true',
-                    'soulbound': 'true'
-                }
+                },
+                soulbound=True
             )
             placement += 1
 

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -1730,12 +1730,11 @@ async def forge_master_poudrin(cmd):
         id_server=cmd.guild.id,
         id_user=user_data.id_user,
         item_type=ewcfg.it_cosmetic,
-        item_props=item_props
+        item_props=item_props,
+        soulbound=True
     )
 
     ewutils.logMsg("Master poudrin created. Slime stored: {}, Cosmetic ID = {}".format(user_data.slimes, new_item_id))
-
-    itm_utils.soulbind(new_item_id)
 
     user_data.slimes = 0
     user_data.persist()

--- a/ew/cmd/item/itemcmds.py
+++ b/ew/cmd/item/itemcmds.py
@@ -1065,20 +1065,9 @@ async def manually_edit_item_properties(cmd):
         column_name = cmd.tokens[2]
         column_value = cmd.tokens[3]
 
-        target_data = bknd_core.get_cache_result(obj_type="EwItem", id_item = item_id)
-        if target_data is not False:
-            target_data.get("item_props").update({column_name: column_value})
-            bknd_core.cache_data(obj_type="EwItem", data=target_data)
-
-        bknd_core.execute_sql_query("REPLACE INTO items_prop({}, {}, {}) VALUES(%s, %s, %s)".format(
-            ewcfg.col_id_item,
-            ewcfg.col_name,
-            ewcfg.col_value
-        ), (
-            item_id,
-            column_name,
-            column_value
-        ))
+        target_item = EwItem(id_item=item_id)
+        target_item.item_props[column_name] = column_value
+        target_item.persist()
 
         response = "Edited item with ID {}. It's {} value has been set to {}.".format(item_id, column_name, column_value)
 

--- a/ew/cmd/kingpin/kingpincmds.py
+++ b/ew/cmd/kingpin/kingpincmds.py
@@ -301,10 +301,9 @@ async def create(cmd):
         id_server=cmd.guild.id,
         id_user=recipient.id,
         item_type=ewcfg.it_cosmetic,
-        item_props=item_props
+        item_props=item_props,
+        soulbound=True
     )
-
-    itm_utils.soulbind(new_item_id)
 
     response = 'Item "{}" with ID {} successfully created.'.format(item_name, new_item_id)
     return await fe_utils.send_response(response, cmd)
@@ -366,12 +365,12 @@ async def exalt(cmd):
             item_type=medallion.item_type,
             id_user=user_id,
             id_server=cmd.guild.id,
-            item_props=medallion_props
+            item_props=medallion_props,
+            soulbound=True
         )
 
         # Soulbind the medallion. A player can get at most twice, but later on a new command could be added to destroy them/trade them in.
         # I imagine this would be something similar to how players can destroy Australium Wrenches in TF2, which broadcasts a message to everyone in the game, or something.
-        itm_utils.soulbind(medallion_id)
 
         response = "**{} has been gifted the Double Halloween Medallion!!**\n".format(display_name)
     elif ewcfg.swilldermuk_active:
@@ -395,10 +394,9 @@ async def exalt(cmd):
                 item_type=mask.item_type,
                 id_user=recipient.id,
                 id_server=cmd.guild.id,
-                item_props=mask_props
+                item_props=mask_props,
+                soulbound=True
             )
-
-            itm_utils.soulbind(mask_id)
 
             response = "In light of their supreme reign over Swilldermuk, and in honor of their pranking prowess, {} recieves the Janus Mask!".format(recipient.display_name)
 
@@ -418,10 +416,9 @@ async def exalt(cmd):
                 item_type=sword.item_type,
                 id_user=recipient.id,
                 id_server=cmd.guild.id,
-                item_props=sword_props
+                item_props=sword_props,
+                soulbound=True
             )
-
-            itm_utils.soulbind(sword_id)
 
             response = "In response to their unparalleled ability to let everything go to shit and be the laughingstock of all of NLACakaNM, {} recieves the SWORD OF SEETHING! God help us all...".format(recipient.display_name)
     else:

--- a/ew/static/weapons.py
+++ b/ew/static/weapons.py
@@ -821,7 +821,6 @@ weapon_list = [
         vendors=[ewcfg.vendor_dojo, ewcfg.vendor_breakroom],
         classes=[ewcfg.weapon_class_burning],
         stat=ewcfg.stat_molotov_kills,
-        captcha_length=4,
         str_brandish=["{name} lights {weapon}'s fuse for just a second. Heheh, just you wait."]
     ),
     EwWeapon(  # 16
@@ -1315,7 +1314,7 @@ weapon_list = [
         acquisition=ewcfg.acquisition_smelting,
         stat=ewcfg.stat_staff_kills,
         # sap_cost = 2,
-        captcha_length=10,
+        # captcha_length=4,
         str_brandish=["{name} lifts {weapon} and begins to chant unholy incantations! Small rocks slowly rise from the ground around them... \n\nWhoops, they forgot the last bit. The spell collapses."]
     ),
     EwWeapon(  # 31
@@ -1339,7 +1338,7 @@ weapon_list = [
         classes=[ewcfg.weapon_class_farming, ewcfg.weapon_class_juvie],
         stat=ewcfg.stat_hoe_kills,
         # sap_cost = 2,
-        captcha_length=2,
+        # captcha_length=2,
         is_tool=1,
         str_brandish=["{name} takes the piece of hay out of their mouth and spits chewing tobacco onto the ground! Varmints round here get {weapon} to the face."]
     ),
@@ -1364,7 +1363,7 @@ weapon_list = [
         classes=[ewcfg.weapon_class_farming, ewcfg.weapon_class_juvie],
         stat=ewcfg.stat_pitchfork_kills,
         # sap_cost = 2,
-        captcha_length=2,
+        # captcha_length=2,
         is_tool=1,
         str_brandish=["{name} raises {weapon} into the air. Kill them! Kill them all!"]
     ),
@@ -1389,7 +1388,7 @@ weapon_list = [
         classes=[ewcfg.weapon_class_farming, ewcfg.weapon_class_juvie],
         stat=ewcfg.stat_shovel_kills,
         # sap_cost = 2,
-        captcha_length=2,
+        # captcha_length=2,
         is_tool=1,
         str_brandish=["{name} rams {weapon} into the ground. Time to strike the earth!"]
     ),
@@ -1414,7 +1413,7 @@ weapon_list = [
         classes=[ewcfg.weapon_class_farming, ewcfg.weapon_class_juvie],
         stat=ewcfg.stat_slimeringcan_kills,
         # sap_cost = 2,
-        captcha_length=2,
+        # captcha_length=2,
         is_tool=1,
         str_brandish=["OK, {name}. I get that you're trying to be scary with {weapon} and all. It's a fucking watering can. Get real, garden boy."]
     ),
@@ -1443,7 +1442,7 @@ weapon_list = [
         price=0,
         stat=ewcfg.stat_fingernails_kills,
         # sap_cost = 3,
-        captcha_length=8,
+        # captcha_length=2,
         str_brandish=[""]
     ),
     EwWeapon(  # 35


### PR DESCRIPTION
 - !editprops is not a terrifying mess-machine now
 - Retire now checks if the user has an apartment (rent != 0)
 - Default EwApartment location is now nowhere
 - execute_sql_query now has an option to return the lastrowid for insert statements
 - item_create given an option to overwrite defined soulbound status
 - as a result of the last 2, goonscape stat capes will now be properly soulbound, and I can manually enter the sql to update old capes
 - !aptupgrade and !addkey now actually stop users from spamming, as well as bitch at users who try to