### PR TITLE
Small fix to !jump, faction commands and new emotes for !boo

### DIFF
--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -604,8 +604,14 @@ async def dab(cmd):
     if (user_data.life_state == ewcfg.life_state_enlisted or user_data.life_state == ewcfg.life_state_kingpin) and user_data.faction == ewcfg.faction_killers:
         response = '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_slime3 + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_ck + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + '\n' + "{emote}" + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_slime1 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + "{emote}" + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_ck + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_ck + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_slime1 + ewcfg.emote_slime3 + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_ck + ewcfg.emote_ck + ewcfg.emote_slime1 + ewcfg.emote_ck
         final_response = response.format(emote=random.choice(ewcfg.dab_emotes))
-        await fe_utils.send_response(final_response, cmd)
-
+        
+    #Other factions being dumb
+    elif (user_data.life_state == ewcfg.life_state_enlisted or user_data.life_state == ewcfg.life_state_kingpin) and user_data.faction == ewcfg.faction_rowdys:
+	final_response = "The fuck you think you're doing, bustah?"
+    else:
+	final_response = "You're too much of a coward to !dab, dumbass."
+	
+    await fe_utils.send_response(final_response, cmd)
 
 """
 	Rowdys THRASH
@@ -618,8 +624,14 @@ async def thrash(cmd):
     if (user_data.life_state == ewcfg.life_state_enlisted or user_data.life_state == ewcfg.life_state_kingpin) and user_data.faction == ewcfg.faction_rowdys:
         response = '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_slime3 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_slime1 + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_rf + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + '\n' + "{emote}" + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_slime1 + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + "{emote}" + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime3 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_slime1 + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf + ewcfg.emote_rf
         final_response = response.format(emote=random.choice(ewcfg.thrash_emotes))
-        await fe_utils.send_response(final_response, cmd)
+        
+    #Other factions being dumb	
+    elif (user_data.life_state == ewcfg.life_state_enlisted or user_data.life_state == ewcfg.life_state_kingpin) and user_data.faction == ewcfg.faction_killers:
+	final_response = "EXCUSE ME <@177731019322032128> WE GOT A TRAITOR HERE" # Yeah it @s Ben Saint lol
+    else:
+	final_response = "You're too much of a coward to !thrash, dumbass."
 
+    await fe_utils.send_response(final_response, cmd)
 
 """
 	Ghosts BOO
@@ -631,9 +643,14 @@ async def boo(cmd):
 
     if user_data.life_state == ewcfg.life_state_corpse or user_data.life_state == ewcfg.life_state_grandfoe:
         resp_cont = EwResponseContainer(id_server=user_data.id_server)
+        response = '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + "{emote}" + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + "{emote}" + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead
+        final_response = response.format(emote=random.choice(ewcfg.boo_emotes))
 
-        response = '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + ewcfg.emote_ghost + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_srs + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_ghost + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead + '\n' + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_blank + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_negaslime + ewcfg.emote_srs + ewcfg.emote_negaslime + ewcfg.emote_staydead + ewcfg.emote_staydead
-        await fe_utils.send_response(response, cmd)
+    #Other factions being dumb
+    else:
+	final_response = "Why would you want to lower yourself to the level of a filthy ghost?"
+    
+    await fe_utils.send_response(final_response, cmd)	
     # resp_cont.add_channel_response(cmd.message.channel.name, response)
     # if user_data.life_state == ewcfg.life_state_corpse or user_data.life_state == ewcfg.life_state_grandfoe:
     # await resp_cont.post()
@@ -658,8 +675,12 @@ async def dance(cmd):
     if user_data.life_state == ewcfg.life_state_juvenile:
         response = random.choice(comm_cfg.dance_responses).format(cmd.author_id.display_name)
         response = "{} {} {}".format(ewcfg.emote_slime3, response, ewcfg.emote_slime3)
-        await fe_utils.send_response(response, cmd, format_name=False)
+    
+    #Other factions being dumb
+    else:
+	response = "You don't feel groovy enough to dance right now."
 
+    await fe_utils.send_response(response, cmd, format_name=False)
 
 """
 	Slimecorp PROPAGANDIZES

--- a/ew/cmd/cmds/cmdcmds.py
+++ b/ew/cmd/cmds/cmdcmds.py
@@ -989,12 +989,6 @@ async def jump(cmd):
 
                     return
 
-    # Ghosts and kingpins can't jump
-    elif user_data.life_state == ewcfg.life_state_corpse:
-        response = "You're already dead. You'd just ghost hover above the drop."
-    elif user_data.life_state == ewcfg.life_state_kingpin:
-        response = "You try to end things right here. Sadly, the gangster sycophants that kiss the ground you walk on grab your ankles in desperation and prevent you from suicide. Oh, the price of fame."
-
     # If a poi has a jump destination specificied, go there.
     elif poi.jump_dest != '':
         resp_cont = EwResponseContainer(client=cmd.client, id_server=user_data.id_server)
@@ -1085,44 +1079,55 @@ async def jump(cmd):
         roll = random.randrange(25)
         # Small chance to do parkour
         if roll == 0:
-            response = "You start running and taking momentum to then make the fucking highest jump you've ever done. When you reach the ground, you somehow manage to do a sommersault landing. Damn, guess you were good at parkour in the end!"
-        else:
+            response = "You start running and taking the momentum to then make the fucking highest jump you've ever done. When you reach the ground, you somehow manage to land a backflip. Damn, guess you were good at parkour in the end!"
+        # Bigger chance to fuck up
+	if roll >= 1 and roll <=4:
+	    response = "You start running and taking the momentum to then make the fucking highest jump you've ever done. You fuck up midair and end up landing face first, breaking your teeth. What did you expect?"
+	else:
             response = "You jump. Nope. Still not good at parkour."
     
     # Jump off the cliffs
     else:
-        response = "Hmm. The cliff looks safe enough. You imagine, with the proper diving posture, you'll be able to land in the slime unharmed. You steel yourself for the fall, run along the cliff, and swan dive off its steep edge. Of course, you forgot that the Slime Sea is highly corrosive, there are several krakens there, and you can't swim. Welp, time to die."
+	# Ghosts and kingpins can't jump
+    	elif user_data.life_state == ewcfg.life_state_corpse:
+        	response = "You're already dead. You'd just hover above the drop."
+    	elif user_data.life_state == ewcfg.life_state_kingpin:
+        	response = "You try to end things right here. Sadly, the gangster sycophants that kiss the ground you walk on grab your ankles in desperation and prevent you from suicide. Oh, the price of fame."
+	
+	# Everyone else fucking dies
+        else:
+		response = "Hmm. The cliff looks safe enough. You imagine, with the proper diving posture, you'll be able to land in the slime unharmed. You steel yourself for the fall, run along the cliff, and swan dive off its steep edge. Of course, you forgot that the Slime Sea is highly corrosive, there are several krakens there, and you can't swim. Welp, time to die."
 
-        # Take all of the player's items
-        cliff_inventory = bknd_item.inventory(id_server=cmd.guild.id, id_user=user_data.id_user)
-        for item in cliff_inventory:
-            item_object = EwItem(id_item=item.get('id_item'))
-            # Don't put soulbound items in the sea.
-            if item.get('soulbound'):
-                pass
+        	# Take all of the player's items
+        	cliff_inventory = bknd_item.inventory(id_server=cmd.guild.id, id_user=user_data.id_user)
+        	for item in cliff_inventory:
+            	item_object = EwItem(id_item=item.get('id_item'))
+            	# Don't put soulbound items in the sea.
+            	if item.get('soulbound'):
+                	pass
 
-            # If a weapon is equipped or sidearmed, put it directly in the sea's inventory.
-            elif item_object.item_type == ewcfg.it_weapon:
-                if item.get('id_item') == user_data.weapon or item.get('id_item') == user_data.sidearm:
-                    bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
-                # Otherwise goes through regular cliff !toss checks. 
-                else:
-                    item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)
+		    # If a weapon is equipped or sidearmed, put it directly in the sea's inventory.
+		    elif item_object.item_type == ewcfg.it_weapon:
+			if item.get('id_item') == user_data.weapon or item.get('id_item') == user_data.sidearm:
+			    bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
+			# Otherwise goes through regular cliff !toss checks. 
+			else:
+			    item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)
 
-            # If an item is adorned, put it directly into the sea's inventory.
-            elif item_object.item_props.get('adorned') == 'true':
-                bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
+		    # If an item is adorned, put it directly into the sea's inventory.
+		    elif item_object.item_props.get('adorned') == 'true':
+			bknd_item.give_item(id_item=item_object.id_item, id_user=ewcfg.poi_id_slimesea, id_server=cmd.guild.id)
 
-            # Otherwise goes through regular cliff !toss checks.
-            else:
-                item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)
+		    # Otherwise goes through regular cliff !toss checks.
+		    else:
+			item_off(id_item=item.get('id_item'), is_pushed_off=True, item_name=item.get('name'), id_server=cmd.guild.id)
 
-        # Kill the player
-        user_data.trauma = ewcfg.trauma_id_environment
-        die_resp = await user_data.die(cause=ewcfg.cause_cliff)
-        if die_resp != EwResponseContainer(id_server=cmd.guild.id):
-            await die_resp.post()
-    return await fe_utils.send_response(response, cmd)
+		# Kill the player
+		user_data.trauma = ewcfg.trauma_id_environment
+		die_resp = await user_data.die(cause=ewcfg.cause_cliff)
+		if die_resp != EwResponseContainer(id_server=cmd.guild.id):
+		    await die_resp.post()
+	    return await fe_utils.send_response(response, cmd)
 
 
 async def push(cmd):

--- a/ew/static/cfg.py
+++ b/ew/static/cfg.py
@@ -1997,7 +1997,7 @@ emote_delete_tweet = emote_blank
 # Slime twitter verified checkmark
 emote_verified = "<:slime_checkmark:797234128398319626>"
 
-# Emotes for !thrash and !dab variants
+# Emotes for !thrash, !dab and !boo variants
 emote_benkart = "<a:benkart:644520407734550529>"
 emote_munchykart = "<a:munchykart:644520408002854913>"
 emote_taasenchamp = "<:TaasenChamp:804369420583567392>"
@@ -2009,7 +2009,10 @@ emote_strawberrymilk = "<:strawberrymilk:431282128421126144>"
 emote_dab = "<a:dab:805341290220093450>"
 emote_thrash = "<a:thrash:805341344331202620>"
 emote_benwtf = "<:benwtf:981830620080635914>"
-
+emote_gcool = "<:ghostcool:985321953218945075>"
+emote_nslog = "<:negalog:698581983537922189>"
+emote_invsrs = "<:srs_invert:657793228673646612>"
+emote_nega111 = "<:nega111:638907899778695188>"
 
 # Miscellaneous
 emote_tfwslime = "<:tfwslime:713609663832391680>"
@@ -2035,9 +2038,17 @@ emote_munchykart,
 emote_freaker,
 emote_sweetmunch,
 emote_strawberrymilk,
-emote_thrash,
+emote_thrash
 ]
 
+boo_emotes = [
+emote_moon,
+emote_ghost,
+emote_gcool,
+emote_nslog,
+emote_invsrs,
+emote_nega111
+]
 
 # Dice emote list
 emotes_dice = [


### PR DESCRIPTION
- A small mistake made it so ghosts and kingpins got the Slime's End Cliffs messages instead of the non poi ones outside there. Also added the chance to break your teeth while jumping, because why not.
- Now the faction specific commands (!dab, !thrash, !boo and !dance) have a response for people from other factions executing them. Why would they do that? Don't know, but I thought a small response from the bot acknowledging their stupidity was neat.
- !boo has changing emotes on the sides like !dab and !thrash.